### PR TITLE
Enhance PySpringModel: Add Self Type Hint, Improve Error Handling, and Add Tests

### DIFF
--- a/py_spring_model/core/model.py
+++ b/py_spring_model/core/model.py
@@ -1,6 +1,5 @@
 import contextlib
-from typing import ClassVar, Iterator, Optional, Type
-
+from typing import ClassVar, Iterator, Optional, Type, Self
 from loguru import logger
 from sqlalchemy import Engine, MetaData
 from sqlalchemy.engine.base import Connection
@@ -28,7 +27,10 @@ class PySpringModel(SQLModel):
     @classmethod
     def get_primary_key_columns(cls, table_cls: Type["PySpringModel"]) -> list[str]:
         metadata = cls.get_metadata()
-        table = metadata.tables[str(table_cls.__tablename__)]
+        table = metadata.tables.get(str(table_cls.__tablename__))
+        if table is None:
+            raise ValueError(f"Table {table_cls.__tablename__} not found in metadata")
+        
         return [column.name for column in table.primary_key.columns]
 
     @classmethod
@@ -78,7 +80,7 @@ class PySpringModel(SQLModel):
             raise ValueError("[MODEL_LOOKUP NOT SET] Model lookup is not set")
         return {str(_model.__tablename__): _model for _model in cls._models}
 
-    def clone(self) -> "PySpringModel":
+    def clone(self) -> Self:
         return self.model_validate_json(self.model_dump_json())
 
     @classmethod

--- a/tests/test_py_spring_model.py
+++ b/tests/test_py_spring_model.py
@@ -1,0 +1,83 @@
+
+
+import pytest
+from sqlalchemy import create_engine, MetaData
+from sqlalchemy.engine.base import Connection
+from sqlmodel import Field, SQLModel
+from py_spring_model.core.py_spring_session import PySpringSession
+from py_spring_model import PySpringModel
+
+
+class SampleModel(PySpringModel, table=True):
+    id: int = Field(default=None, primary_key=True)
+    name: str
+
+
+class TestPySpringModel:
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        self.engine = create_engine("sqlite:///:memory:", echo=False)
+        self.metadata = MetaData()
+        PySpringModel.set_engine(self.engine)
+        PySpringModel.set_metadata(self.metadata)
+        yield
+        PySpringModel._engine = None
+        PySpringModel._metadata = None
+        PySpringModel._connection = None
+
+    def test_set_and_get_engine(self):
+        assert PySpringModel.get_engine() == self.engine
+
+    def test_set_and_get_metadata(self):
+        assert PySpringModel.get_metadata() == self.metadata
+
+    def test_set_and_get_connection(self):
+        connection = PySpringModel.get_connection()
+        assert isinstance(connection, Connection)
+        assert not connection.closed
+
+    def test_get_connection_reuse(self):
+        connection1 = PySpringModel.get_connection()
+        connection2 = PySpringModel.get_connection()
+        assert connection1 is connection2
+
+    def test_create_session(self):
+        session = PySpringModel.create_session()
+        assert isinstance(session, PySpringSession)
+        assert session.bind == self.engine
+
+    def test_create_managed_session_success(self):
+        with PySpringModel.create_managed_session() as session:
+            assert isinstance(session, PySpringSession)
+            assert session.bind == self.engine
+
+    def test_create_managed_session_exception(self):
+        class TestException(Exception):
+            pass
+
+        with pytest.raises(TestException):
+            with PySpringModel.create_managed_session() as session:
+                assert isinstance(session, PySpringSession)
+                raise TestException("Simulated error")
+
+        with PySpringModel.create_managed_session() as session:
+            # Ensure session is still functional after exception
+            assert isinstance(session, PySpringSession)
+
+    def test_set_models_and_get_model_lookup(self):
+        PySpringModel.set_models([SampleModel])
+        model_lookup = PySpringModel.get_model_lookup()
+        assert model_lookup["samplemodel"] == SampleModel
+
+    def test_get_primary_key_columns(self):
+        PySpringModel.set_metadata(SQLModel.metadata)
+        PySpringModel.set_models([SampleModel])
+        SampleModel.metadata.create_all(self.engine)
+        primary_keys = PySpringModel.get_primary_key_columns(SampleModel)
+        assert primary_keys == ["id"]
+
+    def test_clone(self):
+        sample = SampleModel(id=1, name="Test User")
+        cloned_sample = sample.clone()
+        assert cloned_sample.id == sample.id
+        assert cloned_sample.name == sample.name


### PR DESCRIPTION
### Summary
This pull request introduces several enhancements to the `PySpringModel` class, including improved type hinting, better error handling, and comprehensive test coverage.

### Changes
1. **Type Hinting**:
   - Updated the `clone` method in `PySpringModel` to use the `Self` type hint, ensuring that subclasses can return themselves as the return type of the method.

2. **Error Handling**:
   - Enhanced the `get_primary_key_columns` method to raise a clear `ValueError` if the specified table is not found in the metadata.

3. **Testing**:
   - Added a new test file, `tests/test_py_spring_model.py`, to cover the following functionalities:
     - Setting and getting the engine, metadata, and connection.
     - Creating and managing sessions using `create_session` and `create_managed_session`.
     - Retrieving primary key columns.
     - Cloning models using the updated `clone` method.
     - Ensuring functionality remains intact after exceptions in managed sessions.

### Rationale
These changes improve the robustness of the `PySpringModel` class by leveraging modern Python type hinting features and introducing stricter error handling. Comprehensive tests ensure the stability and reliability of the class for future development.

### Testing
- All tests have been added to `tests/test_py_spring_model.py`.
- Verified that all tests pass in the local environment.

### Impact
- Enhances developer experience by providing precise type hints.
- Increases confidence in the `PySpringModel` implementation through comprehensive testing.
- Improves clarity and error messaging for easier debugging.
