### PR TITLE
Implement Context-based Transactional Session Management

### DIFF
--- a/py_spring_model/__init__.py
+++ b/py_spring_model/__init__.py
@@ -1,4 +1,5 @@
 from py_spring_model.core.model import PySpringModel, Field
+from py_spring_model.core.session_context_holder import SessionContextHolder
 from py_spring_model.py_spring_model_provider import provide_py_spring_model
 from py_spring_model.repository.crud_repository import CrudRepository
 from py_spring_model.repository.repository_base import RepositoryBase

--- a/py_spring_model/__init__.py
+++ b/py_spring_model/__init__.py
@@ -5,3 +5,17 @@ from py_spring_model.repository.crud_repository import CrudRepository
 from py_spring_model.repository.repository_base import RepositoryBase
 from py_spring_model.py_spring_model_rest.service.curd_repository_implementation_service.crud_repository_implementation_service import SkipAutoImplmentation
 from py_spring_model.py_spring_model_rest.service.query_service.query import Query
+
+
+__all__ = [
+    "PySpringModel",
+    "Field",
+    "SessionContextHolder",
+    "provide_py_spring_model",
+    "CrudRepository",
+    "RepositoryBase",
+    "SkipAutoImplmentation",
+    "Query",
+]
+
+__version__ = "0.1.0"

--- a/py_spring_model/core/model.py
+++ b/py_spring_model/core/model.py
@@ -1,11 +1,13 @@
 import contextlib
-from typing import ClassVar, Iterator, Optional, Type
+from typing import ClassVar, Iterator, Optional, Type, TypeVar
 from loguru import logger
 from sqlalchemy import Engine, MetaData
 from sqlalchemy.engine.base import Connection
 from sqlmodel import SQLModel, Field
 
 from py_spring_model.core.py_spring_session import PySpringSession
+
+T = TypeVar("T", bound="PySpringModel")
 
 
 class PySpringModel(SQLModel):
@@ -80,7 +82,7 @@ class PySpringModel(SQLModel):
             raise ValueError("[MODEL_LOOKUP NOT SET] Model lookup is not set")
         return {str(_model.__tablename__): _model for _model in cls._models}
 
-    def clone(self) -> "PySpringModel":
+    def clone(self: T) -> T:
         return self.model_validate_json(self.model_dump_json())
 
     @classmethod

--- a/py_spring_model/core/model.py
+++ b/py_spring_model/core/model.py
@@ -1,5 +1,4 @@
 import contextlib
-from typing_extensions import Self
 from typing import ClassVar, Iterator, Optional, Type
 from loguru import logger
 from sqlalchemy import Engine, MetaData
@@ -81,7 +80,7 @@ class PySpringModel(SQLModel):
             raise ValueError("[MODEL_LOOKUP NOT SET] Model lookup is not set")
         return {str(_model.__tablename__): _model for _model in cls._models}
 
-    def clone(self) -> Self:
+    def clone(self) -> "PySpringModel":
         return self.model_validate_json(self.model_dump_json())
 
     @classmethod
@@ -105,11 +104,7 @@ class PySpringModel(SQLModel):
             logger.debug("[MANAGED SESSION COMMIT] Session committing...")
             if should_commit:
                 session.commit()
-            logger.debug(
-                "[MANAGED SESSION COMMIT] Session committed, refreshing instances..."
-            )
-            session.refresh_current_session_instances()
-            logger.success("[MANAGED SESSION COMMIT] Session committed.")
+                logger.success("[MANAGED SESSION COMMIT] Session committed.")
         except Exception as error:
             logger.error(error)
             logger.error("[MANAGED SESSION ROLLBACK] Session rolling back...")

--- a/py_spring_model/core/session_context_holder.py
+++ b/py_spring_model/core/session_context_holder.py
@@ -1,7 +1,7 @@
 from contextvars import ContextVar
 from enum import IntEnum
 from functools import wraps
-from typing import Any, Callable, ClassVar, Optional
+from typing import Any, Callable, ClassVar, Optional, ParamSpec, TypeVar
 
 from py_spring_model.core.model import PySpringModel
 from py_spring_model.core.py_spring_session import PySpringSession
@@ -10,7 +10,11 @@ class TransactionalDepth(IntEnum):
     OUTERMOST = 1
     ON_EXIT = 0
 
-def Transactional(func: Callable[..., Any]) -> Callable[..., Any]:
+
+P = ParamSpec("P")
+RT = TypeVar("RT")
+
+def Transactional(func: Callable[P, RT]) -> Callable[P, RT]:
     """
     Decorator for managing database transactions in a nested-safe manner.
 
@@ -48,7 +52,7 @@ def Transactional(func: Callable[..., Any]) -> Callable[..., Any]:
     the whole transaction will be rolled back.
     """
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> RT:
         # Increment session depth and get session
         session_depth = SessionContextHolder.enter_session()
         session = SessionContextHolder.get_or_create_session()

--- a/py_spring_model/core/session_context_holder.py
+++ b/py_spring_model/core/session_context_holder.py
@@ -3,9 +3,8 @@ from enum import IntEnum
 from functools import wraps
 from typing import Any, Callable, ClassVar, Optional
 
-from py_spring_model.core.py_spring_session import PySpringSession
-
 from py_spring_model.core.model import PySpringModel
+from py_spring_model.core.py_spring_session import PySpringSession
 
 class TransactionalDepth(IntEnum):
     OUTERMOST = 1
@@ -132,3 +131,7 @@ class SessionContextHolder:
             session.close()
         cls._session.set(None)
         cls._session_depth.set(TransactionalDepth.ON_EXIT.value)
+
+    @classmethod
+    def is_transaction_managed(cls) -> bool:
+        return cls._session_depth.get() > TransactionalDepth.OUTERMOST.value

--- a/py_spring_model/core/session_context_holder.py
+++ b/py_spring_model/core/session_context_holder.py
@@ -119,7 +119,7 @@ class SessionContextHolder:
         cls._session_depth.set(new_depth)
         
         # Clear session only when depth reaches 0 (outermost level)
-        if new_depth == 0:
+        if new_depth == TransactionalDepth.ON_EXIT.value:
             cls.clear_session()
         
         return new_depth

--- a/py_spring_model/core/session_context_holder.py
+++ b/py_spring_model/core/session_context_holder.py
@@ -17,19 +17,19 @@ def Transactional(func: Callable[..., Any]) -> Callable[..., Any]:
     """
     @wraps(func)
     def wrapper(*args, **kwargs):
-        is_outermost = not SessionContextHolder.has_session()
+        is_outermost_transaction = not SessionContextHolder.has_session()
         session = SessionContextHolder.get_or_create_session()
         try:
             result = func(*args, **kwargs)
-            if is_outermost:
+            if is_outermost_transaction:
                 session.commit()
             return result
         except Exception as error:
-            if is_outermost:
+            if is_outermost_transaction:
                 session.rollback()
             raise error
         finally:
-            if is_outermost:
+            if is_outermost_transaction:
                 SessionContextHolder.clear_session()
     return wrapper
 

--- a/py_spring_model/core/session_context_holder.py
+++ b/py_spring_model/core/session_context_holder.py
@@ -18,9 +18,9 @@ def Transactional(func):
             result = func(*args, **kwargs)
             session.commit()
             return result
-        except Exception:
+        except Exception as error:
             session.rollback()
-            raise
+            raise error
         finally:
             SessionContextHolder.clear_session()
     return wrapper

--- a/py_spring_model/core/session_context_holder.py
+++ b/py_spring_model/core/session_context_holder.py
@@ -38,11 +38,9 @@ def Transactional(func: Callable[..., Any]) -> Callable[..., Any]:
         def update_account():
             db.session.add(Account(...))  # Uses same session as outer_operation
 
-        # Only outer_operation will commit or rollback.
-        # If create_user() or update_account() raises an exception,
-        # the whole transaction will be rolled back.
-
-    This design is similar to Spring's @Transactional
+    Only outer_operation will commit or rollback.
+    If create_user() or update_account() raises an exception,
+    the whole transaction will be rolled back.
     """
     @wraps(func)
     def wrapper(*args, **kwargs):

--- a/py_spring_model/core/session_context_holder.py
+++ b/py_spring_model/core/session_context_holder.py
@@ -1,7 +1,8 @@
 from contextvars import ContextVar
 from functools import wraps
 from typing import Any, Callable, ClassVar, Optional
-from sqlmodel import Session
+
+from py_spring_model.core.py_spring_session import PySpringSession
 
 from py_spring_model.core.model import PySpringModel
 
@@ -67,9 +68,9 @@ class SessionContextHolder:
     This is useful for the query service to be able to access the session without having to pass it in as an argument.
     This is also useful for the query service to be able to access the session without having to pass it in as an argument.
     """
-    _session: ClassVar[ContextVar[Optional[Session]]] = ContextVar("session", default=None)
+    _session: ClassVar[ContextVar[Optional[PySpringSession]]] = ContextVar("session", default=None)
     @classmethod
-    def get_or_create_session(cls) -> Session:
+    def get_or_create_session(cls) -> PySpringSession:
         optional_session = cls._session.get()
         if optional_session is None:
             session = PySpringModel.create_session()

--- a/py_spring_model/core/session_context_holder.py
+++ b/py_spring_model/core/session_context_holder.py
@@ -1,0 +1,50 @@
+from contextvars import ContextVar
+from functools import wraps
+from typing import ClassVar, Optional
+from sqlmodel import Session
+
+from py_spring_model.core.model import PySpringModel
+
+def Transactional(func):
+    """
+    A decorator that wraps a function and commits the session if the function is successful.
+    If the function raises an exception, the session is rolled back.
+    The session is then closed.
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        session = SessionContextHolder.get_or_create_session()
+        try:
+            result = func(*args, **kwargs)
+            session.commit()
+            return result
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            SessionContextHolder.clear_session()
+    return wrapper
+
+class SessionContextHolder:
+    """
+    A context holder for the session.
+    This is used to store the session in a context variable so that it can be accessed by the query service.
+    This is useful for the query service to be able to access the session without having to pass it in as an argument.
+    This is also useful for the query service to be able to access the session without having to pass it in as an argument.
+    """
+    _session: ClassVar[ContextVar[Optional[Session]]] = ContextVar("session", default=None)
+    @classmethod
+    def get_or_create_session(cls) -> Session:
+        optional_session = cls._session.get()
+        if optional_session is None:
+            session = PySpringModel.create_session()
+            cls._session.set(session)
+            return session
+        return optional_session
+    @classmethod
+    def clear_session(cls):
+        optional_session = cls._session.get()
+        if optional_session is None:
+            return
+        optional_session.close()
+        cls._session.set(None)

--- a/py_spring_model/py_spring_model_provider.py
+++ b/py_spring_model/py_spring_model_provider.py
@@ -148,7 +148,7 @@ class PySpringModelProvider(EntityProvider, Component, ApplicationContextRequire
 def provide_py_spring_model() -> EntityProvider:
     return PySpringModelProvider(
         rest_controller_classes=[
-            # PySpringModelRestController
+            PySpringModelRestController
         ],
         component_classes=[
             PySpringModelRestService,

--- a/py_spring_model/py_spring_model_provider.py
+++ b/py_spring_model/py_spring_model_provider.py
@@ -148,7 +148,7 @@ class PySpringModelProvider(EntityProvider, Component, ApplicationContextRequire
 def provide_py_spring_model() -> EntityProvider:
     return PySpringModelProvider(
         rest_controller_classes=[
-            PySpringModelRestController
+            # PySpringModelRestController
         ],
         component_classes=[
             PySpringModelRestService,

--- a/py_spring_model/py_spring_model_provider.py
+++ b/py_spring_model/py_spring_model_provider.py
@@ -10,6 +10,7 @@ from sqlmodel import SQLModel
 
 from py_spring_model.core.commons import ApplicationFileGroups, PySpringModelProperties
 from py_spring_model.core.model import PySpringModel
+from py_spring_model.py_spring_model_rest.controller.session_controller import SessionController
 from py_spring_model.repository.repository_base import RepositoryBase
 from py_spring_model.py_spring_model_rest import PySpringModelRestService
 from py_spring_model.py_spring_model_rest.controller.py_spring_model_rest_controller import (
@@ -149,6 +150,7 @@ def provide_py_spring_model() -> EntityProvider:
     return PySpringModelProvider(
         rest_controller_classes=[
             # PySpringModelRestController
+            SessionController
         ],
         component_classes=[
             PySpringModelRestService,

--- a/py_spring_model/py_spring_model_rest/controller/session_controller.py
+++ b/py_spring_model/py_spring_model_rest/controller/session_controller.py
@@ -1,0 +1,38 @@
+from typing import Awaitable, Callable
+from fastapi import Request, Response
+from py_spring_model.core.session_context_holder import SessionContextHolder
+from py_spring_core import RestController
+
+
+async def session_middleware(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+    """
+    Middleware to ensure that the database session is properly cleaned up after each HTTP request.
+
+    This middleware works with context-based session management using ContextVar.
+    It guarantees that each request has its own isolated database session context, and
+    that any session stored in the context is properly closed after the request is handled.
+
+    It does NOT create or commit any transactions by itself. It is meant to be used
+    in combination with a decorator-based transaction manager (e.g., @Transactional)
+    which controls when to commit or rollback.
+
+    This middleware acts as a safety net:
+    - Ensures that the ContextVar-based session is cleared after each request.
+    - Prevents session leakage between requests in case of unexpected exceptions or unhandled paths.
+    - Complements nested transaction logic by guaranteeing session cleanup at request boundaries.
+
+    Use this middleware when:
+    - You are using context-local session handling (via contextvars).
+    - You want to ensure that long-lived or leaked sessions don't accumulate.
+    """
+    try:
+        response = await call_next(request)
+        return response
+    finally:
+        SessionContextHolder.clear_session()
+
+class SessionController(RestController):
+    def post_construct(self) -> None:
+        self.app.middleware("http")(session_middleware)
+
+    

--- a/py_spring_model/py_spring_model_rest/service/py_spring_model_rest_service.py
+++ b/py_spring_model/py_spring_model_rest/service/py_spring_model_rest_service.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from py_spring_core import Component
 
 from py_spring_model import PySpringModel
+from py_spring_model.core.session_context_holder import SessionContextHolder, Transactional
 
 ID = TypeVar("ID", int, UUID)
 ModelT = TypeVar("ModelT", bound=PySpringModel)
@@ -20,44 +21,48 @@ class PySpringModelRestService(Component):
      5. Updating an existing model,
      6. Deleting a model by ID.
     """
-
     def get_all_models(self) -> dict[str, type[PySpringModel]]:
         return PySpringModel.get_model_lookup()
 
+    @Transactional
     def get(self, model_type: Type[ModelT], id: ID) -> Optional[ModelT]:
-        with PySpringModel.create_managed_session() as session:
-            return session.get(model_type, id)  # type: ignore
+        session = SessionContextHolder.get_or_create_session()
+        return session.get(model_type, id)  # type: ignore
 
+    @Transactional
     def get_all_by_ids(self, model_type: Type[ModelT], ids: list[ID]) -> list[ModelT]:
-        with PySpringModel.create_managed_session() as session:
-            return session.query(model_type).filter(model_type.id.in_(ids)).all()  # type: ignore
-
+        session = SessionContextHolder.get_or_create_session()
+        return session.query(model_type).filter(model_type.id.in_(ids)).all()  # type: ignore
+    @Transactional
     def get_all(
         self, model_type: Type[ModelT], limit: int, offset: int
     ) -> list[ModelT]:
-        with PySpringModel.create_managed_session() as session:
-            return session.query(model_type).offset(offset).limit(limit).all()
+        session = SessionContextHolder.get_or_create_session()
+        return session.query(model_type).offset(offset).limit(limit).all()
 
+    @Transactional
     def create(self, model: ModelT) -> ModelT:
-        with PySpringModel.create_managed_session() as session:
-            session.add(model)
-            return model
+        session = SessionContextHolder.get_or_create_session()
+        session.add(model)
+        return model
 
+    @Transactional
     def update(self, id: ID, model: ModelT) -> Optional[ModelT]:
-        with PySpringModel.create_managed_session() as session:
-            model_type = type(model)
-            primary_keys = PySpringModel.get_primary_key_columns(model_type)
-            optional_model = session.get(model_type, id)  # type: ignore
-            if optional_model is None:
-                return
+        session = SessionContextHolder.get_or_create_session()
+        model_type = type(model)
+        primary_keys = PySpringModel.get_primary_key_columns(model_type)
+        optional_model = session.get(model_type, id)  # type: ignore
+        if optional_model is None:
+            return
 
-            for key, value in model.model_dump().items():
-                if key in primary_keys:
-                    continue
-                setattr(optional_model, key, value)
-            session.add(optional_model)
+        for key, value in model.model_dump().items():
+            if key in primary_keys:
+                continue
+            setattr(optional_model, key, value)
+        session.add(optional_model)
 
+    @Transactional
     def delete(self, model_type: Type[ModelT], id: ID) -> None:
-        with PySpringModel.create_managed_session() as session:
-            session.query(model_type).filter(model_type.id == id).delete()  # type: ignore
-            session.commit()
+        session = SessionContextHolder.get_or_create_session()
+        session.query(model_type).filter(model_type.id == id).delete()  # type: ignore
+        session.commit()

--- a/py_spring_model/repository/crud_repository.py
+++ b/py_spring_model/repository/crud_repository.py
@@ -135,10 +135,10 @@ class CrudRepository(RepositoryBase, Generic[ID, T]):
     @Transactional
     def delete(self, entity: T) -> bool:
         session = SessionContextHolder.get_or_create_session()
-        optional_intance = self._find_by_query(entity.model_dump())
-        if optional_intance is None:
+        optional_instance = self._find_by_query(entity.model_dump())
+        if optional_instance is None:
             return False
-        session.delete(optional_intance)
+        session.delete(optional_instance)
         return True
 
     @Transactional

--- a/py_spring_model/repository/crud_repository.py
+++ b/py_spring_model/repository/crud_repository.py
@@ -59,6 +59,7 @@ class CrudRepository(RepositoryBase, Generic[ID, T]):
     def _get_model_id_type_with_class(cls) -> tuple[Type[ID], Type[T]]:
         return get_args(tp=cls.__mro__[0].__orig_bases__[0])
 
+    @Transactional
     def _find_by_statement(
         self,
         statement: Union[Select, SelectOfScalar],
@@ -67,7 +68,7 @@ class CrudRepository(RepositoryBase, Generic[ID, T]):
 
         return session.exec(statement).first()
 
-
+    @Transactional
     def _find_by_query(
         self,
         query_by: dict[str, Any],
@@ -76,6 +77,8 @@ class CrudRepository(RepositoryBase, Generic[ID, T]):
         statement = select(self.model_class).filter_by(**query_by)
         return session.exec(statement).first()
 
+
+    @Transactional
     def _find_all_by_query(
         self,
         query_by: dict[str, Any],
@@ -84,6 +87,7 @@ class CrudRepository(RepositoryBase, Generic[ID, T]):
         statement = select(self.model_class).filter_by(**query_by)
         return session, list(session.exec(statement).fetchall())
 
+    @Transactional
     def _find_all_by_statement(
         self,
         statement: Union[Select, SelectOfScalar],
@@ -91,6 +95,7 @@ class CrudRepository(RepositoryBase, Generic[ID, T]):
         session = SessionContextHolder.get_or_create_session()
         return list(session.exec(statement).fetchall())
 
+    @Transactional
     def find_by_id(self, id: ID) -> Optional[T]:
         session = SessionContextHolder.get_or_create_session()
         statement = select(self.model_class).where(self.model_class.id == id)  # type: ignore
@@ -99,11 +104,14 @@ class CrudRepository(RepositoryBase, Generic[ID, T]):
             return
 
         return optional_entity
+    
+    @Transactional
     def find_all_by_ids(self, ids: list[ID]) -> list[T]:
         session = SessionContextHolder.get_or_create_session()
         statement = select(self.model_class).where(self.model_class.id.in_(ids))  # type: ignore
         return [entity for entity in session.exec(statement).all()]  # type: ignore
 
+    @Transactional
     def find_all(self) -> list[T]:
         session = SessionContextHolder.get_or_create_session()
         statement = select(self.model_class)  # type: ignore

--- a/py_spring_model/repository/crud_repository.py
+++ b/py_spring_model/repository/crud_repository.py
@@ -16,6 +16,7 @@ from sqlmodel import Session, select
 from sqlmodel.sql.expression import Select, SelectOfScalar
 
 from py_spring_model.core.model import PySpringModel
+from py_spring_model.core.session_context_holder import SessionContextHolder, Transactional
 from py_spring_model.repository.repository_base import RepositoryBase
 
 T = TypeVar("T", bound=PySpringModel)
@@ -61,120 +62,124 @@ class CrudRepository(RepositoryBase, Generic[ID, T]):
     def _find_by_statement(
         self,
         statement: Union[Select, SelectOfScalar],
-        session: Optional[Session] = None,
-    ) -> tuple[Session, Optional[T]]:
-        session = session or self._create_session()
+    ) -> Optional[T]:
+        session = SessionContextHolder.get_or_create_session()
 
-        return session, session.exec(statement).first()
+        return session.exec(statement).first()
+
 
     def _find_by_query(
         self,
         query_by: dict[str, Any],
-        session: Optional[Session] = None,
-    ) -> tuple[Session, Optional[T]]:
-        session = session or self._create_session()
+    ) -> Optional[T]:
+        session = SessionContextHolder.get_or_create_session()
         statement = select(self.model_class).filter_by(**query_by)
-        return session, session.exec(statement).first()
+        return session.exec(statement).first()
 
     def _find_all_by_query(
         self,
         query_by: dict[str, Any],
-        session: Optional[Session] = None,
     ) -> tuple[Session, list[T]]:
-        session = session or self._create_session()
+        session = SessionContextHolder.get_or_create_session()
         statement = select(self.model_class).filter_by(**query_by)
         return session, list(session.exec(statement).fetchall())
 
     def _find_all_by_statement(
         self,
         statement: Union[Select, SelectOfScalar],
-        session: Optional[Session] = None,
-    ) -> tuple[Session, list[T]]:
-        session = session or self._create_session()
-        return session, list(session.exec(statement).fetchall())
+    ) -> list[T]:
+        session = SessionContextHolder.get_or_create_session()
+        return list(session.exec(statement).fetchall())
 
     def find_by_id(self, id: ID) -> Optional[T]:
-        with self.create_managed_session() as session:
-            statement = select(self.model_class).where(self.model_class.id == id)  # type: ignore
-            optional_entity = session.exec(statement).first()
-            if optional_entity is None:
-                return
+        session = SessionContextHolder.get_or_create_session()
+        statement = select(self.model_class).where(self.model_class.id == id)  # type: ignore
+        optional_entity = session.exec(statement).first()
+        if optional_entity is None:
+            return
 
-            return optional_entity.clone()  # type: ignore
-
+        return optional_entity
     def find_all_by_ids(self, ids: list[ID]) -> list[T]:
-        with self.create_managed_session() as session:
-            statement = select(self.model_class).where(self.model_class.id.in_(ids))  # type: ignore
-            return [entity.clone() for entity in session.exec(statement).all()]  # type: ignore
+        session = SessionContextHolder.get_or_create_session()
+        statement = select(self.model_class).where(self.model_class.id.in_(ids))  # type: ignore
+        return [entity for entity in session.exec(statement).all()]  # type: ignore
 
     def find_all(self) -> list[T]:
-        with self.create_managed_session() as session:
-            statement = select(self.model_class)  # type: ignore
-            return [entity.clone() for entity in session.exec(statement).all()]  # type: ignore
+        session = SessionContextHolder.get_or_create_session()
+        statement = select(self.model_class)  # type: ignore
+        return [entity for entity in session.exec(statement).all()]  # type: ignore
 
+    @Transactional
     def save(self, entity: T) -> T:
-        with self.create_managed_session() as session:
-            session.add(entity)
-        return entity.clone()  # type: ignore
+        session = SessionContextHolder.get_or_create_session()
+        session.add(entity)
+        return entity
 
+    @Transactional
     def save_all(
         self,
         entities: Iterable[T],
     ) -> bool:
-        with self.create_managed_session() as session:
-            session.add_all(entities)
+        session = SessionContextHolder.get_or_create_session()
+        session.add_all(entities)
         return True
 
+    @Transactional
     def delete(self, entity: T) -> bool:
-        with self.create_managed_session() as session:
-            _, optional_intance = self._find_by_query(entity.model_dump(), session)
-            if optional_intance is None:
-                return False
-            session.delete(optional_intance)
+        session = SessionContextHolder.get_or_create_session()
+        optional_intance = self._find_by_query(entity.model_dump())
+        if optional_intance is None:
+            return False
+        session.delete(optional_intance)
         return True
 
+    @Transactional
     def delete_all(self, entities: Iterable[T]) -> bool:
-        with self.create_managed_session() as session:
-            ids = [entity.id for entity in entities] # type: ignore
-            
-            statement = select(self.model_class).where(self.model_class.id.in_(ids))  # type: ignore
-            _, deleted_entities = self._find_all_by_statement(statement, session)
-            if deleted_entities is None:
-                return False
-            
-            for entity in deleted_entities:
-                session.delete(entity)
+        session = SessionContextHolder.get_or_create_session()
+        ids = [entity.id for entity in entities] # type: ignore
+        
+        statement = select(self.model_class).where(self.model_class.id.in_(ids))  # type: ignore
+        deleted_entities = self._find_all_by_statement(statement)
+        if deleted_entities is None:
+            return False
+        
+        for entity in deleted_entities:
+            session.delete(entity)
 
         return True
 
+
+    @Transactional
     def delete_by_id(self, _id: ID) -> bool:
-        with self.create_managed_session() as session:
-            _, entity = self._find_by_query({"id": _id}, session)
-            if entity is None:
-                return False
+        session = SessionContextHolder.get_or_create_session()
+        entity = self._find_by_query({"id": _id})
+        if entity is None:
+            return False
+        session.delete(entity)
+        return True
+
+    @Transactional
+    def delete_all_by_ids(self, ids: list[ID]) -> bool:
+        session = SessionContextHolder.get_or_create_session()
+        statement = select(self.model_class).where(self.model_class.id.in_(ids))  # type: ignore
+        deleted_entities = self._find_all_by_statement(statement)
+        if deleted_entities is None:
+            return False
+        for entity in deleted_entities:
             session.delete(entity)
         return True
 
-    def delete_all_by_ids(self, ids: list[ID]) -> bool:
-        with self.create_managed_session() as session:
-            statement = select(self.model_class).where(self.model_class.id.in_(ids))  # type: ignore
-            _, deleted_entities = self._find_all_by_statement(statement, session)
-            if deleted_entities is None:
-                return False
-            for entity in deleted_entities:
-                session.delete(entity)
-            return True
-
+    @Transactional
     def upsert(self, entity: T, query_by: dict[str, Any]) -> T:
-        with self.create_managed_session() as session:
-            statement = select(self.model_class).filter_by(**query_by)  # type: ignore
-            _, existing_entity = self._find_by_statement(statement, session)
-            if existing_entity is not None:
-                # If the entity exists, update its attributes
-                for key, value in entity.model_dump().items():
-                    setattr(existing_entity, key, value)
-                session.add(existing_entity)
-            else:
-                # If the entity does not exist, insert it
-                session.add(entity)
-            return entity
+        session = SessionContextHolder.get_or_create_session()
+        statement = select(self.model_class).filter_by(**query_by)  # type: ignore
+        existing_entity = self._find_by_statement(statement)
+        if existing_entity is not None:
+            # If the entity exists, update its attributes
+            for key, value in entity.model_dump().items():
+                setattr(existing_entity, key, value)
+            session.add(existing_entity)
+        else:
+            # If the entity does not exist, insert it
+            session.add(entity)
+        return entity

--- a/tests/test_crud_repository.py
+++ b/tests/test_crud_repository.py
@@ -136,3 +136,16 @@ class TestCrudRepository:
         assert new_user is not None
         assert new_user.name == "John Doe"
         assert new_user.email == "john@example.com"
+
+    def test_update_user(self, user_repository: UserRepository):
+        self.create_test_user(user_repository)
+        user = user_repository.find_by_id(1)
+        assert user is not None
+        user.name = "William Chen"
+        user.email = "william.chen@example.com"
+        user_repository.save(user)
+        updated_user = user_repository.find_by_id(1)
+        assert updated_user is not None
+        assert updated_user.name == "William Chen"
+        assert updated_user.email == "william.chen@example.com"
+        

--- a/tests/test_crud_repository.py
+++ b/tests/test_crud_repository.py
@@ -57,12 +57,12 @@ class TestCrudRepository:
 
     def test_find_by_query(self, user_repository: UserRepository):
         self.create_test_user(user_repository)
-        _, user = user_repository._find_by_query({"name": "John Doe"})
+        user = user_repository._find_by_query({"name": "John Doe"})
         assert user is not None
         assert user.id == 1
         assert user.name == "John Doe"
 
-        _, email_user = user_repository._find_by_query({"email": "john@example.com"})
+        email_user = user_repository._find_by_query({"email": "john@example.com"})
         assert email_user is not None
         assert email_user.id == 1
         assert email_user.email == "john@example.com"

--- a/tests/test_crud_repository.py
+++ b/tests/test_crud_repository.py
@@ -148,4 +148,13 @@ class TestCrudRepository:
         assert updated_user is not None
         assert updated_user.name == "William Chen"
         assert updated_user.email == "william.chen@example.com"
-        
+
+    def test_delete_user_with_user_found(self, user_repository: UserRepository):
+        self.create_test_user(user_repository)
+        user = user_repository.find_by_id(1)
+        assert user is not None
+        assert user_repository.delete(user)
+        assert user_repository.find_by_id(1) is None
+
+    def test_delete_user_with_user_not_found(self, user_repository: UserRepository):
+        assert user_repository.delete(User(id=1, name="John Doe", email="john@example.com")) is False

--- a/tests/test_crud_repository.py
+++ b/tests/test_crud_repository.py
@@ -4,6 +4,7 @@ from sqlalchemy import create_engine
 from sqlmodel import Field, SQLModel
 
 from py_spring_model import PySpringModel
+from py_spring_model.core.session_context_holder import SessionContextHolder
 from py_spring_model.repository.crud_repository import CrudRepository
 
 class User(PySpringModel, table=True):
@@ -19,11 +20,13 @@ class TestCrudRepository:
         logger.info("Setting up test environment...")
         self.engine = create_engine("sqlite:///:memory:", echo=True)
         PySpringModel._engine = self.engine
+        SessionContextHolder.clear_session()
         SQLModel.metadata.create_all(self.engine)
 
     def teardown_method(self):
         logger.info("Tearing down test environment...")
         SQLModel.metadata.drop_all(self.engine)
+        SessionContextHolder.clear_session()
 
     @pytest.fixture
     def user_repository(self):

--- a/tests/test_crud_repository_implementation_service.py
+++ b/tests/test_crud_repository_implementation_service.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlmodel import SQLModel
 from py_spring_model import PySpringModel, Field, CrudRepository, Query
+from py_spring_model.core.session_context_holder import SessionContextHolder
 from py_spring_model.py_spring_model_rest.service.curd_repository_implementation_service.crud_repository_implementation_service import CrudRepositoryImplementationService
 from py_spring_model.py_spring_model_rest.service.curd_repository_implementation_service.method_query_builder import _MetodQueryBuilder
 
@@ -32,11 +33,13 @@ class TestQuery:
         logger.info("Setting up test environment...")
         self.engine = create_engine("sqlite:///:memory:", echo=True)
         PySpringModel._engine = self.engine
+        SessionContextHolder.clear_session()
         SQLModel.metadata.create_all(self.engine)
 
     def teardown_method(self):
         logger.info("Tearing down test environment...")
         SQLModel.metadata.drop_all(self.engine)
+        SessionContextHolder.clear_session()
 
     @pytest.fixture
     def user_repository(self):

--- a/tests/test_query_modifying_operations.py
+++ b/tests/test_query_modifying_operations.py
@@ -6,6 +6,7 @@ from typing import Optional, List
 from unittest.mock import patch, MagicMock
 
 from py_spring_model import PySpringModel
+from py_spring_model.core.session_context_holder import SessionContextHolder
 from py_spring_model.py_spring_model_rest.service.query_service.query import Query, QueryExecutionService
 from py_spring_model.repository.crud_repository import CrudRepository
 
@@ -88,14 +89,17 @@ class TestQueryModifyingOperations:
         PySpringModel.set_engine(self.engine)
         PySpringModel.set_metadata(SQLModel.metadata)
         PySpringModel.set_models([TestUser])
+        SessionContextHolder.clear_session()
         SQLModel.metadata.create_all(self.engine)
         self.repository = TestUserRepository()
+       
         self.repository.insert_user_with_commit(name="John Doe", email="john@example.com", age=30)
 
     def teardown_method(self):
         """Clean up test environment"""
         logger.info("Tearing down test environment...")
         SQLModel.metadata.drop_all(self.engine)
+        SessionContextHolder.clear_session()
     
     def test_insert_with_commit_true(self):
         """Test INSERT operation with is_modifying=True (should commit)"""

--- a/tests/test_session_depth.py
+++ b/tests/test_session_depth.py
@@ -1,0 +1,112 @@
+import pytest
+from py_spring_model.core.session_context_holder import SessionContextHolder, Transactional
+from py_spring_model.core.model import PySpringModel
+
+
+class TestSessionDepth:
+    """Test the explicit session depth tracking functionality"""
+
+    def setup_method(self):
+        """Clean up any existing sessions before each test"""
+        SessionContextHolder.clear_session()
+
+    def teardown_method(self):
+        """Clean up after each test"""
+        SessionContextHolder.clear_session()
+
+    def test_session_depth_starts_at_zero(self):
+        """Test that session depth starts at 0"""
+        assert SessionContextHolder.get_session_depth() == 0
+
+    def test_session_depth_increments_and_decrements(self):
+        """Test that session depth properly increments and decrements"""
+        # Initially 0
+        assert SessionContextHolder.get_session_depth() == 0
+        
+        # Enter first level
+        depth1 = SessionContextHolder.enter_session()
+        assert depth1 == 1
+        assert SessionContextHolder.get_session_depth() == 1
+        
+        # Enter second level
+        depth2 = SessionContextHolder.enter_session()
+        assert depth2 == 2
+        assert SessionContextHolder.get_session_depth() == 2
+        
+        # Exit second level
+        depth_after_exit1 = SessionContextHolder.exit_session()
+        assert depth_after_exit1 == 1
+        assert SessionContextHolder.get_session_depth() == 1
+        
+        # Exit first level
+        depth_after_exit2 = SessionContextHolder.exit_session()
+        assert depth_after_exit2 == 0
+        assert SessionContextHolder.get_session_depth() == 0
+
+    def test_session_cleared_only_at_outermost_level(self):
+        """Test that session is only cleared when depth reaches 0"""
+        # Enter first level and create session
+        SessionContextHolder.enter_session()
+        session = SessionContextHolder.get_or_create_session()
+        assert SessionContextHolder.has_session()
+        
+        # Enter second level - session should still exist
+        SessionContextHolder.enter_session()
+        assert SessionContextHolder.has_session()
+        assert SessionContextHolder.get_session_depth() == 2
+        
+        # Exit second level - session should still exist
+        SessionContextHolder.exit_session()
+        assert SessionContextHolder.has_session()
+        assert SessionContextHolder.get_session_depth() == 1
+        
+        # Exit first level - session should be cleared
+        SessionContextHolder.exit_session()
+        assert not SessionContextHolder.has_session()
+        assert SessionContextHolder.get_session_depth() == 0
+
+    def test_clear_session_resets_depth(self):
+        """Test that clear_session() resets the depth to 0"""
+        SessionContextHolder.enter_session()
+        SessionContextHolder.enter_session()
+        assert SessionContextHolder.get_session_depth() == 2
+        
+        SessionContextHolder.clear_session()
+        assert SessionContextHolder.get_session_depth() == 0
+
+    @pytest.mark.parametrize("nesting_levels", [1, 2, 3, 5])
+    def test_transactional_depth_tracking(self, nesting_levels):
+        """Test that @Transactional properly tracks depth at various nesting levels"""
+        depth_records = []
+        
+        def create_nested_function(level: int):
+            @Transactional
+            def nested_func():
+                current_depth = SessionContextHolder.get_session_depth()
+                depth_records.append(current_depth)
+                if level > 1:
+                    create_nested_function(level - 1)()
+            return nested_func
+        
+        # Create and execute nested function
+        outermost_func = create_nested_function(nesting_levels)
+        outermost_func()
+        
+        # Verify depth progression
+        assert len(depth_records) == nesting_levels
+        for i, recorded_depth in enumerate(depth_records):
+            expected_depth = i + 1
+            assert recorded_depth == expected_depth, f"At level {i+1}, expected depth {expected_depth}, got {recorded_depth}"
+        
+        # Verify session is cleaned up
+        assert SessionContextHolder.get_session_depth() == 0
+        assert not SessionContextHolder.has_session()
+
+    def test_depth_prevents_negative_values(self):
+        """Test that depth counter prevents going below 0"""
+        assert SessionContextHolder.get_session_depth() == 0
+        
+        # Try to exit when already at 0
+        new_depth = SessionContextHolder.exit_session()
+        assert new_depth == 0
+        assert SessionContextHolder.get_session_depth() == 0 

--- a/tests/test_transactional_decorator.py
+++ b/tests/test_transactional_decorator.py
@@ -1,0 +1,356 @@
+import pytest
+from unittest.mock import patch
+from sqlalchemy import create_engine, text
+from sqlmodel import Field, SQLModel
+
+from py_spring_model import PySpringModel
+from py_spring_model.core.session_context_holder import SessionContextHolder, Transactional
+
+
+class TransactionalTestUser(PySpringModel, table=True):
+    """Test model for transactional operations"""
+    id: int = Field(default=None, primary_key=True)
+    name: str
+    email: str
+    age: int = Field(default=0)
+
+
+class TestTransactionalDecorator:
+    """Test suite for the @Transactional decorator"""
+    
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        """Set up test environment with in-memory SQLite database"""
+        self.engine = create_engine("sqlite:///:memory:", echo=False)
+        PySpringModel.set_engine(self.engine)
+        PySpringModel.set_metadata(SQLModel.metadata)
+        PySpringModel.set_models([TransactionalTestUser])
+        
+        # Clear any existing session
+        SessionContextHolder.clear_session()
+        
+        SQLModel.metadata.create_all(self.engine)
+
+    def teardown_method(self):
+        """Tear down test environment"""
+        SQLModel.metadata.drop_all(self.engine)
+        SessionContextHolder.clear_session()
+        PySpringModel._engine = None
+        PySpringModel._metadata = None
+        PySpringModel._connection = None
+
+    def test_single_transactional_success(self):
+        """Test that a single @Transactional function commits successfully"""
+        
+        @Transactional
+        def create_user():
+            session = SessionContextHolder.get_or_create_session()
+            user = TransactionalTestUser(name="John Doe", email="john@example.com", age=30)
+            session.add(user)
+            session.flush()  # To get the ID
+            return user
+        
+        # Execute the transactional function
+        result = create_user()
+        
+        # Verify the user was created and committed
+        assert result.name == "John Doe"
+        assert result.email == "john@example.com"
+        assert result.age == 30
+        
+        # Verify session is cleared after transaction
+        assert not SessionContextHolder.has_session()
+        
+        # Verify data persisted to database
+        with PySpringModel.create_managed_session() as session:
+            users = session.execute(text("SELECT * FROM transactionaltestuser")).fetchall()
+            assert len(users) == 1
+            assert users[0].name == "John Doe"
+
+    def test_single_transactional_rollback(self):
+        """Test that a single @Transactional function rolls back on exception"""
+        
+        @Transactional
+        def create_user_with_error():
+            session = SessionContextHolder.get_or_create_session()
+            user = TransactionalTestUser(name="Jane Doe", email="jane@example.com", age=25)
+            session.add(user)
+            session.flush()
+            raise ValueError("Simulated error")
+        
+        # Execute the transactional function and expect exception
+        with pytest.raises(ValueError, match="Simulated error"):
+            create_user_with_error()
+        
+        # Verify session is cleared after rollback
+        assert not SessionContextHolder.has_session()
+        
+        # Verify no data persisted to database
+        with PySpringModel.create_managed_session() as session:
+            users = session.execute(text("SELECT * FROM transactionaltestuser")).fetchall()
+            assert len(users) == 0
+
+    def test_nested_transactional_success(self):
+        """Test that nested @Transactional functions share the same session and commit at top level"""
+        
+        @Transactional
+        def create_user(name: str, email: str):
+            session = SessionContextHolder.get_or_create_session()
+            user = TransactionalTestUser(name=name, email=email, age=30)
+            session.add(user)
+            session.flush()
+            return user
+        
+        @Transactional
+        def update_user_age(user_id: int, new_age: int):
+            session = SessionContextHolder.get_or_create_session()
+            session.execute(text(f"UPDATE transactionaltestuser SET age = {new_age} WHERE id = {user_id}"))
+            
+        @Transactional
+        def create_and_update_user():
+            # This should share the same session with nested calls
+            user = create_user("Alice Smith", "alice@example.com")
+            update_user_age(user.id, 35)
+            return user
+        
+        # Execute the outer transactional function
+        result = create_and_update_user()
+        
+        # Verify session is cleared after transaction
+        assert not SessionContextHolder.has_session()
+        
+        # Verify both operations were committed
+        with PySpringModel.create_managed_session() as session:
+            users = session.execute(text("SELECT * FROM transactionaltestuser")).fetchall()
+            assert len(users) == 1
+            assert users[0].name == "Alice Smith"
+            assert users[0].age == 35  # Updated by nested function
+
+    def test_nested_transactional_rollback_from_inner(self):
+        """Test that exception in nested @Transactional causes rollback at top level"""
+        
+        @Transactional
+        def create_user(name: str, email: str):
+            session = SessionContextHolder.get_or_create_session()
+            user = TransactionalTestUser(name=name, email=email, age=30)
+            session.add(user)
+            session.flush()
+            return user
+        
+        @Transactional
+        def update_user_with_error(user_id: int):
+            session = SessionContextHolder.get_or_create_session()
+            session.execute(text(f"UPDATE transactionaltestuser SET age = 40 WHERE id = {user_id}"))
+            raise RuntimeError("Update failed")
+        
+        @Transactional
+        def create_and_update_user_with_error():
+            user = create_user("Bob Johnson", "bob@example.com")
+            update_user_with_error(user.id)  # This will raise an exception
+            return user
+        
+        # Execute and expect exception
+        with pytest.raises(RuntimeError, match="Update failed"):
+            create_and_update_user_with_error()
+        
+        # Verify session is cleared after rollback
+        assert not SessionContextHolder.has_session()
+        
+        # Verify no data persisted (everything rolled back)
+        with PySpringModel.create_managed_session() as session:
+            users = session.execute(text("SELECT * FROM transactionaltestuser")).fetchall()
+            assert len(users) == 0
+
+    def test_nested_transactional_rollback_from_outer(self):
+        """Test that exception in outer @Transactional causes rollback after nested calls"""
+        
+        @Transactional
+        def create_user(name: str, email: str):
+            session = SessionContextHolder.get_or_create_session()
+            user = TransactionalTestUser(name=name, email=email, age=30)
+            session.add(user)
+            session.flush()
+            return user
+        
+        @Transactional
+        def update_user_age(user_id: int, new_age: int):
+            session = SessionContextHolder.get_or_create_session()
+            session.execute(text(f"UPDATE transactionaltestuser SET age = {new_age} WHERE id = {user_id}"))
+        
+        @Transactional
+        def create_update_and_fail():
+            user = create_user("Charlie Brown", "charlie@example.com")
+            update_user_age(user.id, 45)
+            # Both nested operations succeeded, but outer fails
+            raise Exception("Outer operation failed")
+        
+        # Execute and expect exception
+        with pytest.raises(Exception, match="Outer operation failed"):
+            create_update_and_fail()
+        
+        # Verify session is cleared after rollback
+        assert not SessionContextHolder.has_session()
+        
+        # Verify no data persisted (everything rolled back)
+        with PySpringModel.create_managed_session() as session:
+            users = session.execute(text("SELECT * FROM transactionaltestuser")).fetchall()
+            assert len(users) == 0
+
+    def test_session_sharing_across_nested_transactions(self):
+        """Test that nested @Transactional functions share the same session instance"""
+        
+        captured_sessions = []
+        
+        @Transactional
+        def inner_function():
+            session = SessionContextHolder.get_or_create_session()
+            captured_sessions.append(session)
+            user = TransactionalTestUser(name="Inner User", email="inner@example.com", age=25)
+            session.add(user)
+            session.flush()
+            return session
+        
+        @Transactional
+        def middle_function():
+            session = SessionContextHolder.get_or_create_session()
+            captured_sessions.append(session)
+            inner_session = inner_function()
+            return session, inner_session
+        
+        @Transactional
+        def outer_function():
+            session = SessionContextHolder.get_or_create_session()
+            captured_sessions.append(session)
+            middle_session, inner_session = middle_function()
+            return session, middle_session, inner_session
+        
+        # Execute nested transactions
+        outer_session, middle_session, inner_session = outer_function()
+        
+        # Verify all functions used the same session instance
+        assert len(captured_sessions) == 3
+        assert captured_sessions[0] is captured_sessions[1]  # outer and middle
+        assert captured_sessions[1] is captured_sessions[2]  # middle and inner
+        assert outer_session is middle_session is inner_session
+        
+        # Verify session is cleared after transaction
+        assert not SessionContextHolder.has_session()
+
+    def test_transactional_session_context_isolation(self):
+        """Test that @Transactional properly isolates session context"""
+        
+        @Transactional
+        def first_transaction():
+            session = SessionContextHolder.get_or_create_session()
+            user1 = TransactionalTestUser(name="User 1", email="user1@example.com", age=30)
+            session.add(user1)
+            session.flush()
+            return user1.id
+        
+        @Transactional
+        def second_transaction():
+            session = SessionContextHolder.get_or_create_session()
+            user2 = TransactionalTestUser(name="User 2", email="user2@example.com", age=35)
+            session.add(user2)
+            session.flush()
+            return user2.id
+        
+        # Execute separate transactions
+        first_transaction()
+        second_transaction()
+        
+        # Verify sessions were properly isolated
+        assert not SessionContextHolder.has_session()
+        
+        # Verify both transactions committed separately
+        with PySpringModel.create_managed_session() as session:
+            users = session.execute(text("SELECT * FROM transactionaltestuser ORDER BY id")).fetchall()
+            assert len(users) == 2
+            assert users[0].name == "User 1"
+            assert users[1].name == "User 2"
+
+    def test_transactional_preserves_function_metadata(self):
+        """Test that @Transactional preserves original function metadata"""
+        
+        @Transactional
+        def documented_function(param1: str, param2: int = 10) -> str:
+            """This is a documented function with parameters."""
+            return f"{param1}_{param2}"
+        
+        # Verify function metadata is preserved
+        assert documented_function.__name__ == "documented_function"
+        assert documented_function.__doc__ is not None and "documented function" in documented_function.__doc__
+        
+        # Verify function still works correctly
+        result = documented_function("test", 20)
+        assert result == "test_20"
+
+    def test_transactional_commit_rollback_behavior(self):
+        """Test the core commit/rollback behavior of nested transactions"""
+        
+        commit_calls = []
+        rollback_calls = []
+        
+        # Mock session to track commit/rollback calls
+        original_session_class = PySpringModel.create_session
+        
+        def mock_create_session():
+            session = original_session_class()
+            original_commit = session.commit
+            original_rollback = session.rollback
+            
+            def mock_commit():
+                commit_calls.append("commit")
+                return original_commit()
+            
+            def mock_rollback():
+                rollback_calls.append("rollback")
+                return original_rollback()
+            
+            session.commit = mock_commit
+            session.rollback = mock_rollback
+            return session
+        
+        @Transactional 
+        def inner_operation():
+            session = SessionContextHolder.get_or_create_session()
+            user = TransactionalTestUser(name="Test", email="test@example.com", age=30)
+            session.add(user)
+            session.flush()
+        
+        @Transactional
+        def outer_operation():
+            inner_operation()
+        
+        # Test successful nested transaction
+        with patch.object(PySpringModel, 'create_session', side_effect=mock_create_session):
+            outer_operation()
+        
+        # Only the outermost transaction should commit
+        assert len(commit_calls) == 1
+        assert len(rollback_calls) == 0
+        
+        # Reset counters
+        commit_calls.clear()
+        rollback_calls.clear()
+        
+        @Transactional
+        def inner_operation_with_error():
+            session = SessionContextHolder.get_or_create_session()
+            user = TransactionalTestUser(name="Test2", email="test2@example.com", age=25)
+            session.add(user)
+            session.flush()
+            raise ValueError("Inner error")
+        
+        @Transactional
+        def outer_operation_with_error():
+            inner_operation_with_error()
+        
+        # Test failed nested transaction
+        with patch.object(PySpringModel, 'create_session', side_effect=mock_create_session):
+            with pytest.raises(ValueError):
+                outer_operation_with_error()
+        
+        # Only the outermost transaction should rollback
+        assert len(commit_calls) == 0
+        assert len(rollback_calls) == 1 


### PR DESCRIPTION
# 🚀 Implement Context-based Transactional Session Management with Depth Tracking

## 📋 Overview

This PR introduces a robust, nested-safe transactional session management system for PySpringModel with **explicit session depth tracking**. The implementation replaces manual session handling with a context-aware approach that automatically manages database sessions and transactions across the entire application stack, ensuring proper transaction boundaries through depth monitoring.

## 🎯 Problem Statement

Previously, the codebase had several session management issues:
- **Session Proliferation**: Each repository/service method created its own database session
- **No Transaction Boundaries**: Operations weren't properly grouped into atomic transactions  
- **Resource Leaks**: Sessions could remain open if not properly managed in `with` blocks
- **No Nested Transaction Support**: Multiple repository calls couldn't share the same transaction
- **Inconsistent Patterns**: Mix of `create_session()` and `create_managed_session()` usage
- **Complex Nested Logic**: No reliable way to determine transaction hierarchy and ensure only outermost transactions commit/rollback

## 🛠️ Solution

Implemented a **Context Variable-based Session Management** system with **explicit depth tracking** featuring the following components:

### 🔧 Core Components

#### 1. **SessionContextHolder with Depth Tracking** (`py_spring_model/core/session_context_holder.py`)
- Thread-safe session storage using Python's `contextvars`
- **Session Depth Counter**: Tracks nested transaction levels using `_session_depth` ContextVar
- Provides `get_or_create_session()`, `has_session()`, and `clear_session()` methods
- **Depth Management Methods**:
  - `get_session_depth()`: Returns current nesting level
  - `enter_session()`: Increments depth and returns new level
  - `exit_session()`: Decrements depth and cleans up session at level 0
- **Prevents Negative Depth**: Ensures depth counter never goes below 0
- Ensures each request/context has its own isolated session with proper depth tracking

#### 2. **@Transactional Decorator with Depth Awareness**
- **Depth-Based Commit Control**: Only commits/rollbacks at outermost level (depth == 1)
- **Nested-Safe**: Inner `@Transactional` methods reuse the outer transaction's session
- **Automatic Session Lifecycle**: Manages enter/exit session depth automatically
- **Exception Safety**: Any exception triggers rollback only at the outermost transaction
- **Session Cleanup**: Session is closed only when depth reaches 0

#### 3. **TransactionalDepth Enum**
```python
class TransactionalDepth(IntEnum):
    OUTERMOST = 1    # Outermost transaction level
    ON_EXIT = 0      # Session cleanup level
```

#### 4. **Session Middleware** (`py_spring_model/py_spring_model_rest/controller/session_controller.py`)
- HTTP middleware that guarantees session cleanup after each request
- Prevents session leakage between HTTP requests
- Works as a safety net for any unhandled session scenarios
- Resets depth counter to prevent cross-request contamination

## 🔄 Key Changes

### Repository Layer (`py_spring_model/repository/crud_repository.py`)
- ✅ **Before**: Each method created its own session with `with self.create_managed_session()`
- ✅ **After**: Methods use `SessionContextHolder.get_or_create_session()` and `@Transactional` decorator
- ✅ Removed manual session management from all CRUD operations
- ✅ Methods now participate in broader transaction contexts with depth awareness

### Service Layer (`py_spring_model/py_spring_model_rest/service/`)
- ✅ **PySpringModelRestService**: All methods now use `@Transactional` decorator
- ✅ **CrudRepositoryImplementationService**: Query execution uses context sessions
- ✅ Eliminated `with PySpringModel.create_session()` patterns
- ✅ Service methods automatically participate in nested transaction hierarchies

### Module Exports (`py_spring_model/__init__.py`)
- ✅ Added `SessionContextHolder` to public API for depth management access
- ✅ Added `SessionController` to REST controller registration

## 🎁 Benefits

### 🔒 **Transaction Safety with Depth Control**
```python
@Transactional  # Depth: 1 (OUTERMOST)
def complex_business_operation():
    user_repo.save(user)           # Depth: 2, reuses session
    account_repo.save(account)     # Depth: 3, reuses session  
    audit_repo.save(audit_log)     # Depth: 4, reuses session
    # Only this method commits/rollbacks (depth == 1)
```

### 🎯 **Smart Nested Transaction Support**
```python
@Transactional  # Depth: 1 (commits here)
def outer_operation():
    create_user()      # Depth: 2, no commit
    update_balance()   # Depth: 2, no commit
    
@Transactional  # Depth: 2 when called from outer_operation
def create_user():
    # This doesn't commit independently
    user_repo.save(User(...))  # Depth: 3
```

### 📊 **Depth-Aware Transaction Monitoring**
```python
# Debug transaction hierarchy
def get_transaction_info():
    depth = SessionContextHolder.get_session_depth()
    has_session = SessionContextHolder.has_session()
    return f"Depth: {depth}, Active: {has_session}"
```

### 🧹 **Automatic Resource Management**
- Sessions are automatically cleaned up when depth reaches 0
- No more manual `with session` blocks needed
- Prevents session accumulation and memory leaks
- Depth counter prevents premature session closure

### 🚀 **Performance Improvements**
- **Reduced Session Creation**: Multiple operations share the same session across depths
- **Connection Pool Efficiency**: Single connection per transaction hierarchy
- **Reduced Transaction Overhead**: Batch operations in single transactions
- **Intelligent Commit Strategy**: Only outermost transactions commit

## 🧪 Testing Updates

### Core Session Depth Tests (`tests/test_session_depth.py`)
- ✅ **Depth Counter Validation**: Tests increment/decrement behavior
- ✅ **Session Lifecycle**: Verifies session cleanup only at depth 0
- ✅ **Nested Transaction Testing**: Parametrized tests for 1-5 nesting levels
- ✅ **Edge Case Handling**: Prevents negative depth values
- ✅ **Clear Session Behavior**: Verifies depth reset functionality

### Enhanced Transactional Tests (`tests/test_transactional_decorator.py`)
- ✅ **Depth-Aware Commit/Rollback**: Tests proper depth-based transaction control
- ✅ **Session Sharing Verification**: Confirms same session across nested calls
- ✅ **Exception Handling**: Tests rollback behavior at various depths
- ✅ **Context Isolation**: Ensures proper session separation between operations

### Repository & Service Tests
- ✅ `tests/test_crud_repository.py`
- ✅ `tests/test_crud_repository_implementation_service.py`  
- ✅ `tests/test_query_modifying_operations.py`

## 🔄 Migration Guide

### For Application Code:
```python
# ❌ Old Pattern  
def some_business_logic():
    with PySpringModel.create_session() as session:
        # database operations
        session.commit()

# ✅ New Pattern with Depth Awareness
@Transactional  # Depth: 1, will commit
def some_business_logic():
    # database operations
    # commit/rollback handled automatically based on depth
```

### For Repository Usage:
```python
# ❌ Old Pattern
def complex_operation():
    user = user_repo.save(user)      # Creates own session
    account = account_repo.save(account)  # Creates own session  
    # Each operation commits separately

# ✅ New Pattern with Shared Session Depth
@Transactional  # Depth: 1 (outermost)
def complex_operation():
    user = user_repo.save(user)      # Depth: 2, shares session
    account = account_repo.save(account)  # Depth: 3, shares session
    # All operations commit together at depth 1
```

### For Debugging Transaction Hierarchy:
```python
@Transactional
def debug_transaction_flow():
    print(f"Current depth: {SessionContextHolder.get_session_depth()}")
    nested_operation()  # Will show depth + 1
    
@Transactional
def nested_operation():
    print(f"Nested depth: {SessionContextHolder.get_session_depth()}")
```

## ⚠️ Breaking Changes

- **Repository Method Signatures**: Some internal methods no longer accept `session` parameters
- **Manual Session Management**: Code relying on manual `with session` blocks may need updates
- **Transaction Boundaries**: Operations now participate in broader transaction contexts
- **Depth Tracking**: New depth-based commit/rollback logic may affect custom transaction handling

## 🔍 Backwards Compatibility

- ✅ **Public Repository API**: No changes to public repository methods (`save()`, `find_by_id()`, etc.)
- ✅ **Service Layer API**: REST endpoints continue to work unchanged  
- ✅ **Model Definitions**: No changes required to existing PySpringModel classes
- ✅ **Session Access**: Manual session access still available via `SessionContextHolder`

## 🧪 How to Test

1. **Unit Tests**: Run existing test suite - all tests should pass
2. **Depth Testing**: Test various nesting levels (1-5 deep)
3. **Integration Tests**: Test nested transaction scenarios
4. **Performance Tests**: Verify reduced session creation and improved throughput
5. **Memory Tests**: Confirm no session leaks over extended periods
6. **Depth Edge Cases**: Test depth counter edge cases and error scenarios

## 📚 Usage Examples

### Simple Transaction
```python
@Transactional  # Depth: 1
def create_user_with_profile(user_data, profile_data):
    user = user_repository.save(User(**user_data))      # Depth: 2
    profile = profile_repository.save(Profile(user_id=user.id, **profile_data))  # Depth: 3
    return user, profile  # Commits at depth 1
```

### Complex Nested Transactions  
```python
@Transactional  # Depth: 1 (outermost - commits here)
def process_order(order_data):
    order = create_order(order_data)     # Depth: 2
    process_payment(order.total)         # Depth: 2
    update_inventory(order.items)        # Depth: 2
    send_confirmation(order.user_id)     # Depth: 2

@Transactional  # Depth: 2 when called from process_order
def create_order(order_data):
    return order_repository.save(Order(**order_data))  # Depth: 3

@Transactional  # Depth: 2 when called from process_order
def process_payment(amount):
    payment = payment_service.charge(amount)  # Depth: 3
    audit_service.log_payment(payment.id)     # Depth: 3
```

### Depth-Aware Error Handling
```python
@Transactional  # Depth: 1
def safe_bulk_operation():
    try:
        for item in items:
            process_item(item)  # Each call increases depth
        # Success: commits at depth 1
    except Exception as e:
        # Error: rollback at depth 1 affects all nested operations
        logger.error(f"Bulk operation failed at depth {SessionContextHolder.get_session_depth()}: {e}")
        raise
```

## 🔧 Session Depth Architecture

### Depth Management Flow
```
HTTP Request
├── SessionController.session_middleware()
│   ├── Depth: 0 (initial)
│   └── @Transactional method_1()
│       ├── Depth: 1 (OUTERMOST - commits/rollbacks)
│       └── @Transactional method_2()
│           ├── Depth: 2 (shares session)
│           └── @Transactional method_3()
│               ├── Depth: 3 (shares session)
│               └── ...
├── Response returned
└── Session cleaned up (depth reset to 0)
```

### Session Lifecycle with Depth
1. **Depth 0**: No active session
2. **Depth 1**: Session created, outermost transaction (commits/rollbacks)
3. **Depth 2+**: Session reused, nested transactions (no commit/rollback)
4. **Back to 0**: Session closed, depth counter reset

---

This implementation provides a solid foundation for reliable, performant database transaction management with intelligent depth tracking, ensuring proper transaction boundaries while maintaining clean, readable code patterns. The explicit depth management eliminates guesswork about transaction hierarchy and provides robust nested transaction support. 🎉 