### PR TITLE
chore: Bump version to 0.1.1 and add create_all_tables property

### DIFF
--- a/py_spring_model/__init__.py
+++ b/py_spring_model/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
     "Query",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/py_spring_model/core/commons.py
+++ b/py_spring_model/core/commons.py
@@ -30,3 +30,4 @@ class PySpringModelProperties(Properties):
     __key__ = "py_spring_model"
     model_file_postfix_patterns: set[str]
     sqlalchemy_database_uri: str
+    create_all_tables: bool = True

--- a/py_spring_model/py_spring_model_provider.py
+++ b/py_spring_model/py_spring_model_provider.py
@@ -114,6 +114,11 @@ class PySpringModelProvider(EntityProvider, Component, ApplicationContextRequire
         return set(class_name_with_class_map.values())
 
     def _create_all_tables(self) -> None:
+        props = self._get_props()
+        if not props.create_all_tables:
+            logger.info("[SQLMODEL TABLE CREATION] Skip creating all tables, set create_all_tables to True to enable.")
+            return
+
         table_names = SQLModel.metadata.tables.keys()
         logger.success(
             f"[SQLMODEL TABLE CREATION] Create all SQLModel tables, engine url: {self.sql_engine.url}, tables: {', '.join(table_names)}"


### PR DESCRIPTION
- Updated version number in `__init__.py` to 0.1.1.
- Added `create_all_tables` property to `PySpringModelProperties` with a default value of True.
- Enhanced `_create_all_tables` method in `PySpringModelProvider` to conditionally skip table creation based on the `create_all_tables` property.