### PR TITLE
`PySpringModelProvider` replaces `provide_py_spring_model()` factory function

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,5 @@
 name: Running pytest
-on: [push, workflow_dispatch]
+on: [push, workflow_dispatch, pull_request]
 jobs:
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,11 +17,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
       - name: Install pdm
         run: pip install pdm
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,8 +3,19 @@ on: [push, workflow_dispatch, pull_request]
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,6 @@ jobs:
         python-version:
           - "3.11"
           - "3.12"
-          - "3.13"
     steps:
       - uses: actions/checkout@v4
 

--- a/py_spring_model/__init__.py
+++ b/py_spring_model/__init__.py
@@ -1,6 +1,6 @@
 from py_spring_model.core.model import PySpringModel, Field
 from py_spring_model.core.session_context_holder import SessionContextHolder, Transactional
-from py_spring_model.py_spring_model_provider import provide_py_spring_model
+from py_spring_model.py_spring_model_provider import PySpringModelProvider
 from py_spring_model.repository.crud_repository import CrudRepository
 from py_spring_model.repository.repository_base import RepositoryBase
 from py_spring_model.py_spring_model_rest.service.curd_repository_implementation_service.crud_repository_implementation_service import SkipAutoImplmentation
@@ -11,7 +11,7 @@ __all__ = [
     "PySpringModel",
     "Field",
     "SessionContextHolder",
-    "provide_py_spring_model",
+    "PySpringModelProvider",
     "CrudRepository",
     "RepositoryBase",
     "SkipAutoImplmentation",
@@ -19,4 +19,4 @@ __all__ = [
     "Transactional",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/py_spring_model/py_spring_model_provider.py
+++ b/py_spring_model/py_spring_model_provider.py
@@ -30,9 +30,15 @@ class PySpringModelProvider(PySpringStarter):
         self.properties_classes.append(PySpringModelProperties)
 
     def on_initialized(self) -> None:
-        assert self.app_context is not None
+        if self.app_context is None:
+            raise RuntimeError(
+                "PySpringModelProvider.on_initialized() called before app_context was set."
+            )
         props = self.app_context.get_properties(PySpringModelProperties)
-        assert props is not None
+        if props is None:
+            raise RuntimeError(
+                "PySpringModelProperties not found. Ensure the 'py_spring_model' key exists in application-properties.json."
+            )
 
         logger.info(
             f"[PYSPRING MODEL PROVIDER INIT] Initialize PySpringModelProvider with app context: {self.app_context}"

--- a/py_spring_model/py_spring_model_provider.py
+++ b/py_spring_model/py_spring_model_provider.py
@@ -1,7 +1,7 @@
 from typing import Type, cast
 
 from loguru import logger
-from py_spring_core import Component, EntityProvider, ApplicationContextRequired
+from py_spring_core import PySpringStarter
 from sqlalchemy import create_engine
 from sqlmodel import SQLModel
 
@@ -15,38 +15,47 @@ from py_spring_model.py_spring_model_rest.service.curd_repository_implementation
 )
 
 
-class ApplicationContextNotSetError(Exception): ...
-
-
-class PySpringModelProvider(EntityProvider, Component, ApplicationContextRequired):
+class PySpringModelProvider(PySpringStarter):
     """
     The `PySpringModelProvider` class is responsible for initializing the PySpring model provider, which includes:
-    - Grouping file paths into class files and model files
     - Dynamically importing model modules
     - Creating all SQLModel tables
     - Setting up the SQLAlchemy engine and connection
     - Registering PySpring model classes and metadata
-
-    This class is a key component in the PySpring model infrastructure, handling the setup and initialization of the model-related functionality.
     """
 
-    def _get_props(self) -> PySpringModelProperties:
-        app_context =  self.get_application_context()
-        assert app_context is not None
-        props = app_context.get_properties(PySpringModelProperties)
+    def on_configure(self) -> None:
+        self.rest_controller_classes.append(SessionController)
+        self.component_classes.append(PySpringModelRestService)
+        self.properties_classes.append(PySpringModelProperties)
+
+    def on_initialized(self) -> None:
+        assert self.app_context is not None
+        props = self.app_context.get_properties(PySpringModelProperties)
         assert props is not None
-        return props
+
+        logger.info(
+            f"[PYSPRING MODEL PROVIDER INIT] Initialize PySpringModelProvider with app context: {self.app_context}"
+        )
+        self.sql_engine = create_engine(
+            url=props.sqlalchemy_database_uri, echo=True
+        )
+        self._init_pyspring_model()
+        self._init_repository_query_implementation()
+
+        if not props.create_all_tables:
+            logger.info("[SQLMODEL TABLE CREATION] Skip creating all tables, set create_all_tables to True to enable.")
+            return
+        self._create_all_tables()
 
     def _get_pyspring_model_inheritors(self) -> set[Type[object]]:
-        # use dict to store all models, use a session to check if all models are mapped
         class_name_with_class_map: dict[str, Type[object]] = {}
         for _cls in set(PySpringModel.__subclasses__()):
             if _cls.__name__ in class_name_with_class_map:
                 continue
             class_name_with_class_map[_cls.__name__] = _cls
-
         return set(class_name_with_class_map.values())
-    
+
     def _create_all_tables(self) -> None:
         table_names = SQLModel.metadata.tables.keys()
         logger.success(
@@ -61,8 +70,8 @@ class PySpringModelProvider(EntityProvider, Component, ApplicationContextRequire
         implementation_service = CrudRepositoryImplementationService()
         logger.info("[QUERY IMPLEMENTATION] Implement query for all CrudRepositories...")
         implementation_service.implement_query_for_all_crud_repository_inheritors()
-        logger.success("[QUERY IMPLEMENTATION] All repository queries are implemnted.")
-        
+        logger.success("[QUERY IMPLEMENTATION] All repository queries are implemented.")
+
     def _init_pyspring_model(self) -> None:
         self._model_classes = self._get_pyspring_model_inheritors()
         PySpringModel.set_engine(self.sql_engine)
@@ -72,32 +81,3 @@ class PySpringModelProvider(EntityProvider, Component, ApplicationContextRequire
         PySpringModel.set_metadata(SQLModel.metadata)
         RepositoryBase.engine = self.sql_engine
         RepositoryBase.connection = self.sql_engine.connect()
-        
-    def provider_init(self) -> None:
-        props = self._get_props()
-        logger.info(
-            f"[PYSPRING MODEL PROVIDER INIT] Initialize PySpringModelProvider with app context: {self.app_context}"
-        )
-        self.sql_engine = create_engine(
-            url=props.sqlalchemy_database_uri, echo=True
-        )
-        self._init_pyspring_model()
-        self._init_repository_query_implementation()
-        props = self._get_props()
-        if not props.create_all_tables:
-            logger.info("[SQLMODEL TABLE CREATION] Skip creating all tables, set create_all_tables to True to enable.")
-            return
-        self._create_all_tables()
-def provide_py_spring_model() -> EntityProvider:
-    return PySpringModelProvider(
-        rest_controller_classes=[
-            # PySpringModelRestController
-            SessionController
-        ],
-        component_classes=[
-            PySpringModelRestService
-        ],
-        properties_classes=[
-            PySpringModelProperties
-        ],
-    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "sqlmodel>=0.0.38",
 ]
 
-requires-python = ">=3.11, <=3.13"
+requires-python = ">=3.11, <3.13"
 readme = "README.md"
 license = {text = "MIT"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "py-spring-core>=0.3.1",
-    "sqlmodel>=0.0.24",
+    "sqlmodel>=0.0.38",
 ]
 
 requires-python = ">=3.11, <3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "William Chen", email = "ow6201231@gmail.com"},
 ]
 dependencies = [
-    "py-spring-core>=0.3.3",
+    "py-spring-core>=0.3.4",
     "sqlmodel>=0.0.38",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "sqlmodel>=0.0.38",
 ]
 
-requires-python = ">=3.11, <3.13"
+requires-python = ">=3.11, <=3.13"
 readme = "README.md"
 license = {text = "MIT"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "William Chen", email = "ow6201231@gmail.com"},
 ]
 dependencies = [
-    "py-spring-core>=0.3.1",
+    "py-spring-core>=0.3.3",
     "sqlmodel>=0.0.38",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,11 @@ authors = [
     {name = "William Chen", email = "ow6201231@gmail.com"},
 ]
 dependencies = [
-    "py-spring-core>=0.0.22",
+    "py-spring-core>=0.3.1",
     "sqlmodel>=0.0.24",
 ]
 
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.11, <3.13"
 readme = "README.md"
 license = {text = "MIT"}
 
@@ -23,10 +23,13 @@ build-backend = "pdm.backend"
 distribution = true
 version = { source = "file", path = "py_spring_model/__init__.py" }
 
+# pdm install -d
 [tool.pdm.dev-dependencies]
 dev = [
     "ruff>=0.6.3",
     "isort>=5.13.2",
     "pytest>=8.3.2",
     "pytest-mock>=3.14.0",
+    "testcontainers[postgres]>=4.0.0",
+    "psycopg2-binary>=2.9.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,8 @@ dev = [
     "testcontainers[postgres]>=4.0.0",
     "psycopg2-binary>=2.9.0",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "e2e: end-to-end tests that boot the full application",
+]

--- a/testcontainers-python/SKILL.md
+++ b/testcontainers-python/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: testcontainers-python
+description: >
+  Use this skill when the user wants to write integration tests or functional tests using Docker
+  containers in Python with the testcontainers-python library. Trigger whenever the user mentions
+  spinning up a database for tests, running Redis/Postgres/MySQL/Kafka/Elasticsearch/MongoDB in a
+  test, testcontainers, Docker container in pytest, integration testing with real services, or wants
+  to replace mocks with real containers. Also trigger when the user says things like "how do I test
+  with a real database", "run a container in my test", "spin up services for testing", "pytest with
+  Docker", or "integration test setup". Even if the user does not mention testcontainers by name,
+  use this skill when the goal is using real containerised services in automated tests.
+---
+
+# testcontainers-python Skill
+
+A skill for using [testcontainers-python](https://github.com/testcontainers/testcontainers-python) — a Python library that spins up Docker containers as real runtime environments for integration and functional tests.
+
+## Core Concept
+
+Testcontainers wraps Docker to give each test (or test session) a fresh, real service — no mocks, no external infra, no leftover state.
+
+```python
+# Typical pattern — context manager starts and stops the container
+with PostgresContainer("postgres:16") as pg:
+    engine = sqlalchemy.create_engine(pg.get_connection_url())
+    # run your test code here
+```
+
+---
+
+## Installation
+
+```bash
+# Install with the extras you need
+pip install testcontainers[postgres]
+pip install testcontainers[redis]
+pip install testcontainers[kafka]
+pip install testcontainers[mysql]
+pip install testcontainers[mongodb]
+pip install testcontainers[elasticsearch]
+pip install testcontainers[minio]
+pip install testcontainers[localstack]
+pip install testcontainers[generic]   # for custom/arbitrary containers
+```
+
+Version 4.0+ uses extras — the old `testcontainers-postgres` style packages are no longer supported.
+
+---
+
+## Available Modules
+
+See `references/modules.md` for the full module list with import paths and constructor signatures.
+
+Key modules:
+- **Databases**: PostgreSQL, MySQL, MariaDB, MongoDB, CockroachDB, ClickHouse, Oracle, DB2, Db2
+- **Cache/Messaging**: Redis, Kafka, RabbitMQ, Pulsar, Azurite
+- **Search**: Elasticsearch, OpenSearch, Weaviate, Qdrant, Chroma
+- **Cloud emulators**: LocalStack (AWS), MinIO, Azurite
+- **Generic / custom**: `DockerContainer`, `ServerContainer`, `GenericContainer`
+
+---
+
+## Core Patterns
+
+### 1. Context Manager (simplest, per-test)
+
+```python
+from testcontainers.postgres import PostgresContainer
+import sqlalchemy
+
+def test_insert():
+    with PostgresContainer("postgres:16") as pg:
+        engine = sqlalchemy.create_engine(pg.get_connection_url())
+        with engine.begin() as conn:
+            conn.execute(sqlalchemy.text("CREATE TABLE t (id int)"))
+            conn.execute(sqlalchemy.text("INSERT INTO t VALUES (1)"))
+            result = conn.execute(sqlalchemy.text("SELECT * FROM t")).fetchall()
+        assert result == [(1,)]
+```
+
+### 2. Pytest Fixture (session-scoped — start once, reuse)
+
+```python
+import pytest
+from testcontainers.postgres import PostgresContainer
+
+@pytest.fixture(scope="session")
+def pg_container():
+    with PostgresContainer("postgres:16") as pg:
+        yield pg
+
+def test_something(pg_container):
+    url = pg_container.get_connection_url()
+    # use url ...
+```
+
+Use `scope="session"` to avoid restarting the container for every test (much faster).  
+Use `scope="function"` when you need full isolation per test.
+
+### 3. Custom / Generic Container
+
+```python
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_strategy import wait_for_logs
+
+with DockerContainer("my-app:latest") \
+        .with_exposed_ports(8080) \
+        .with_env("ENV_VAR", "value") \
+        .with_command("python -m myapp") as container:
+    container.get_exposed_port(8080)  # mapped host port
+```
+
+### 4. Wait Strategies
+
+Containers aren't immediately ready after `.start()`. Use waiting strategies:
+
+```python
+from testcontainers.core.waiting_strategy import (
+    wait_for_logs,          # wait until log output matches a regex
+    DockerReadinessProbe,   # custom callable
+)
+
+# Log-based (most common)
+container = DockerContainer("redis:7").with_exposed_ports(6379)
+container.with_kwargs(network="bridge")
+# built-in modules handle this automatically
+
+# For custom containers:
+container = (
+    DockerContainer("myimage:latest")
+    .with_exposed_ports(8080)
+)
+container.start()
+wait_for_logs(container, r"Application started", timeout=30)
+```
+
+Most built-in modules already implement their own readiness check — you don't need to configure waiting manually.
+
+---
+
+## Common Module Usage
+
+### PostgreSQL
+
+```python
+from testcontainers.postgres import PostgresContainer
+
+with PostgresContainer(
+    image="postgres:16",
+    username="testuser",
+    password="testpass",
+    dbname="testdb",
+    driver="psycopg2",  # or None to exclude driver from URL
+) as pg:
+    url = pg.get_connection_url()  # postgresql+psycopg2://testuser:testpass@localhost:PORT/testdb
+```
+
+### MySQL / MariaDB
+
+```python
+from testcontainers.mysql import MySqlContainer
+from testcontainers.mariadb import MariaDbContainer
+
+with MySqlContainer("mysql:8.0") as mysql:
+    url = mysql.get_connection_url()
+
+with MariaDbContainer("mariadb:10.6") as mariadb:
+    url = mariadb.get_connection_url()
+```
+
+### Redis
+
+```python
+from testcontainers.redis import RedisContainer
+import redis
+
+with RedisContainer("redis:7") as r:
+    client = redis.Redis(
+        host=r.get_container_host_ip(),
+        port=r.get_exposed_port(6379),
+    )
+    client.set("key", "value")
+    assert client.get("key") == b"value"
+```
+
+### MongoDB
+
+```python
+from testcontainers.mongodb import MongoDbContainer
+from pymongo import MongoClient
+
+with MongoDbContainer("mongo:6") as mongo:
+    client = MongoClient(mongo.get_connection_url())
+    db = client.testdb
+```
+
+### Kafka
+
+```python
+from testcontainers.kafka import KafkaContainer
+
+with KafkaContainer("confluentinc/cp-kafka:7.4.0") as kafka:
+    bootstrap_servers = kafka.get_bootstrap_server()
+```
+
+### Elasticsearch
+
+```python
+from testcontainers.elasticsearch import ElasticsearchContainer
+
+with ElasticsearchContainer("elasticsearch:8.6.0") as es:
+    url = es.get_url()  # http://localhost:PORT
+```
+
+### LocalStack (AWS)
+
+```python
+from testcontainers.localstack import LocalStackContainer
+import boto3
+
+with LocalStackContainer(image="localstack/localstack:3.0") as localstack:
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=localstack.get_url(),
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+    s3.create_bucket(Bucket="my-bucket")
+```
+
+### MinIO
+
+```python
+from testcontainers.minio import MinioContainer
+import boto3
+
+with MinioContainer() as minio:
+    client = minio.get_client()  # returns a Minio client
+    # or get boto3-compatible endpoint:
+    endpoint = f"http://{minio.get_container_host_ip()}:{minio.get_exposed_port(9000)}"
+```
+
+---
+
+## Docker-in-Docker (CI)
+
+When running inside a Docker container (e.g., GitHub Actions with DinD):
+
+```yaml
+# GitHub Actions example
+services:
+  docker:
+    image: docker:dind
+    options: --privileged
+
+steps:
+  - run: pip install testcontainers[postgres]
+  - run: pytest
+```
+
+Environment variables to know:
+| Variable | Purpose |
+|---|---|
+| `DOCKER_HOST` | Override Docker daemon socket |
+| `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` | Path for Ryuk's socket |
+| `TESTCONTAINERS_RYUK_DISABLED` | Set `true` to disable Ryuk (resource reaper) |
+| `TESTCONTAINERS_HOST_OVERRIDE` | Override the IP Testcontainers uses to reach containers |
+| `DOCKER_AUTH_CONFIG` | JSON auth for private registries |
+
+---
+
+## Custom Container from Scratch
+
+```python
+from testcontainers.core.container import DockerContainer
+
+class MyServiceContainer(DockerContainer):
+    def __init__(self, image="myrepo/myservice:latest", **kwargs):
+        super().__init__(image=image, **kwargs)
+        self.with_exposed_ports(8080)
+        self.with_env("APP_ENV", "test")
+
+    def get_url(self):
+        host = self.get_container_host_ip()
+        port = self.get_exposed_port(8080)
+        return f"http://{host}:{port}"
+```
+
+---
+
+## Tips & Gotchas
+
+- **Ryuk** is the resource reaper — it automatically removes containers when the Python process exits. Disable with `TESTCONTAINERS_RYUK_DISABLED=true` only if it causes issues.
+- **Port mapping**: containers expose ports dynamically. Always use `get_exposed_port(INTERNAL_PORT)` — never hardcode.
+- **Image versions**: pin specific versions (e.g., `postgres:16`) to avoid flaky tests from upstream image changes.
+- **Network access in CI**: if containers can't reach each other, consider `DockerContainer.with_kwargs(network="host")` or Docker Compose fixtures.
+- **Slow startup**: use `scope="session"` fixtures and a single container per test session for expensive images.
+- **`driver=None`** in `PostgresContainer`: useful with `psycopg` v3 which uses a different URL scheme.
+
+---
+
+## References
+
+- Full module list: `references/modules.md`
+- Official docs: https://testcontainers-python.readthedocs.io/en/latest/
+- GitHub: https://github.com/testcontainers/testcontainers-python

--- a/testcontainers-python/references/modules.md
+++ b/testcontainers-python/references/modules.md
@@ -1,0 +1,82 @@
+# testcontainers-python — Module Reference
+
+All modules are installed via `pip install testcontainers[<extra>]`.
+
+## Databases
+
+| Module | Extra | Import | Container Class |
+|---|---|---|---|
+| PostgreSQL | `postgres` | `from testcontainers.postgres import PostgresContainer` | `PostgresContainer(image, username, password, dbname, driver)` |
+| MySQL | `mysql` | `from testcontainers.mysql import MySqlContainer` | `MySqlContainer(image, username, password, dbname)` |
+| MariaDB | `mysql` | `from testcontainers.mariadb import MariaDbContainer` | `MariaDbContainer(image, username, password, dbname)` |
+| MongoDB | `mongodb` | `from testcontainers.mongodb import MongoDbContainer` | `MongoDbContainer(image)` |
+| CockroachDB | `cockroachdb` | `from testcontainers.cockroachdb import CockroachDBContainer` | `CockroachDBContainer(image)` |
+| Oracle | `oracle` | `from testcontainers.oracle import OracleDbContainer` | `OracleDbContainer(image)` |
+| ClickHouse | `clickhouse` | `from testcontainers.clickhouse import ClickHouseContainer` | `ClickHouseContainer(image)` |
+
+## Cache / Messaging
+
+| Module | Extra | Import | Container Class |
+|---|---|---|---|
+| Redis | `redis` | `from testcontainers.redis import RedisContainer` | `RedisContainer(image)` |
+| Kafka | `kafka` | `from testcontainers.kafka import KafkaContainer` | `KafkaContainer(image)` → `.get_bootstrap_server()` |
+| RabbitMQ | `rabbitmq` | `from testcontainers.rabbitmq import RabbitMqContainer` | `RabbitMqContainer(image)` |
+| Apache Pulsar | `pulsar` | `from testcontainers.pulsar import PulsarContainer` | `PulsarContainer(image)` |
+
+## Search / Vector Stores
+
+| Module | Extra | Import | Container Class |
+|---|---|---|---|
+| Elasticsearch | `elasticsearch` | `from testcontainers.elasticsearch import ElasticsearchContainer` | `ElasticsearchContainer(image)` → `.get_url()` |
+| OpenSearch | `opensearch` | `from testcontainers.opensearch import OpenSearchContainer` | `OpenSearchContainer(image)` |
+| Weaviate | `weaviate` | `from testcontainers.weaviate import WeaviateContainer` | `WeaviateContainer(image)` |
+| Qdrant | `qdrant` | `from testcontainers.qdrant import QdrantContainer` | `QdrantContainer(image)` |
+| Chroma | `chroma` | `from testcontainers.chroma import ChromaContainer` | `ChromaContainer(image)` |
+
+## Cloud Emulators
+
+| Module | Extra | Import | Container Class |
+|---|---|---|---|
+| LocalStack | `localstack` | `from testcontainers.localstack import LocalStackContainer` | `LocalStackContainer(image)` → `.get_url()` |
+| MinIO | `minio` | `from testcontainers.minio import MinioContainer` | `MinioContainer(image)` → `.get_client()` |
+| Azurite | `azurite` | `from testcontainers.azurite import AzuriteContainer` | `AzuriteContainer(image)` |
+
+## Generic / Custom
+
+| Module | Extra | Import | Container Class |
+|---|---|---|---|
+| Generic container | `generic` | `from testcontainers.core.container import DockerContainer` | `DockerContainer(image)` |
+| Server container | `generic` | `from testcontainers.generic import ServerContainer` | `ServerContainer(port, startup_check_fn)` |
+
+## Useful Core Utilities
+
+```python
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_strategy import wait_for_logs
+from testcontainers.core.config import testcontainers_config
+
+# DockerContainer methods:
+.with_exposed_ports(port)        # expose an internal port (mapped randomly on host)
+.with_env(key, value)            # set environment variable
+.with_volume_mapping(host, container, mode="ro")  # mount a volume
+.with_command(cmd)               # override entrypoint command
+.with_kwargs(**docker_kwargs)    # pass raw kwargs to docker-py
+.get_container_host_ip()         # returns host IP reachable from test
+.get_exposed_port(internal_port) # returns mapped host port as string
+.get_logs()                      # returns (stdout, stderr) bytes tuple
+
+# Config:
+testcontainers_config.ryuk_disabled = True
+testcontainers_config.ryuk_docker_socket = "/var/run/docker.sock"
+```
+
+## Connection URL Helpers
+
+Most database containers expose a `get_connection_url()` method returning a SQLAlchemy-compatible URL:
+
+```
+postgresql+psycopg2://user:pass@localhost:PORT/dbname
+mysql+pymysql://user:pass@localhost:PORT/dbname
+```
+
+For non-SQL containers, use `get_container_host_ip()` + `get_exposed_port(N)` to build the URL manually.

--- a/tests/test_e2e_py_spring_model_provider.py
+++ b/tests/test_e2e_py_spring_model_provider.py
@@ -8,7 +8,9 @@ Verifies the full starter lifecycle:
 import json
 import os
 import shutil
+import sys
 import tempfile
+import warnings
 from typing import Optional
 
 import pytest
@@ -48,14 +50,18 @@ class CategoryRepository(CrudRepository[int, Category]):
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _create_app_fixture(db_uri: str, create_all_tables: bool = True):
-    """Create a temporary directory with config files for PySpringApplication."""
-    tmpdir = tempfile.mkdtemp()
-    src_dir = os.path.join(tmpdir, "src")
-    os.makedirs(src_dir, exist_ok=True)
+def _create_app_fixture(db_uri: str, create_all_tables: bool = True, src_dir: str = ""):
+    """Create a temporary directory with config files for PySpringApplication.
 
-    with open(os.path.join(src_dir, "__init__.py"), "w") as f:
-        f.write("")
+    If *src_dir* is provided it is used as-is (caller manages files).
+    Otherwise a fresh ``src/`` directory is created inside a new tmpdir.
+    """
+    tmpdir = tempfile.mkdtemp()
+    if not src_dir:
+        src_dir = os.path.join(tmpdir, "src")
+        os.makedirs(src_dir, exist_ok=True)
+        with open(os.path.join(src_dir, "__init__.py"), "w") as f:
+            f.write("")
 
     app_config = {
         "app_src_target_dir": src_dir,
@@ -493,3 +499,152 @@ class TestPySpringModelProviderPostgres:
         ])
         found = repo.find_all()
         assert len(found) == 2
+
+
+# ---------------------------------------------------------------------------
+# Duplicate model import edge-case tests
+# ---------------------------------------------------------------------------
+
+def _write_source_file(path: str, content: str) -> None:
+    with open(path, "w") as f:
+        f.write(content)
+
+
+@pytest.mark.e2e
+class TestDuplicateModelImport:
+    """Tests for the duplicate model class import issue.
+
+    When a model file (not named ``models.py``) lives in the scanned
+    ``app_src_target_dir`` alongside Components, and a Component imports
+    that model via standard Python import, the model class should only
+    exist once in ``PySpringModel.__subclasses__()``.
+    """
+
+    def _create_src_with_model_and_component(self, tmp_path):
+        """Create a src dir with a model file and a component that imports it."""
+        src_dir = str(tmp_path / "src")
+        os.makedirs(src_dir, exist_ok=True)
+
+        _write_source_file(
+            os.path.join(src_dir, "__init__.py"),
+            "",
+        )
+
+        # Model file — deliberately NOT named "models.py" so it is
+        # not excluded by the default exclude_file_patterns.
+        _write_source_file(
+            os.path.join(src_dir, "order_model.py"),
+            (
+                "from typing import Optional\n"
+                "from sqlmodel import Field\n"
+                "from py_spring_model import PySpringModel\n"
+                "\n"
+                "class Order(PySpringModel, table=True):\n"
+                "    __tablename__ = 'duplicate_test_order'\n"
+                "    id: Optional[int] = Field(default=None, primary_key=True)\n"
+                "    product: str\n"
+                "    amount: int = 0\n"
+            ),
+        )
+
+        # Component that imports the model via regular Python import.
+        # This is the trigger: ClassScanner loads order_model.py first
+        # via ModuleImporter (which does NOT register in sys.modules),
+        # then when it loads order_service.py the "from order_model import Order"
+        # causes Python to import order_model.py a second time.
+        _write_source_file(
+            os.path.join(src_dir, "order_service.py"),
+            (
+                "from py_spring_core import Component\n"
+                "from order_model import Order\n"
+                "\n"
+                "class OrderService(Component):\n"
+                "    def post_construct(self):\n"
+                "        self._order_cls = Order\n"
+            ),
+        )
+
+        return src_dir
+
+    def _cleanup_dynamic_modules(self, src_dir: str):
+        """Remove dynamically-created modules from sys.modules and sys.path."""
+        for mod_name in list(sys.modules):
+            if mod_name in ("order_model", "order_service"):
+                del sys.modules[mod_name]
+        if src_dir in sys.path:
+            sys.path.remove(src_dir)
+
+    def test_model_imported_by_component_should_produce_single_subclass(self, tmp_path):
+        """A model imported by both the scanner and a Component should exist
+        exactly once in PySpringModel.__subclasses__()."""
+        src_dir = self._create_src_with_model_and_component(tmp_path)
+        sys.path.insert(0, src_dir)
+
+        db_path = str(tmp_path / "dup.db")
+        db_uri = f"sqlite:///{db_path}"
+        config_path, tmpdir = _create_app_fixture(db_uri, src_dir=src_dir)
+
+        try:
+            _run_app(config_path)
+
+            order_subclasses = [
+                c for c in PySpringModel.__subclasses__()
+                if c.__name__ == "Order"
+            ]
+
+            # Correct behavior: exactly 1 copy should exist
+            assert len(order_subclasses) == 1, (
+                f"Expected exactly 1 Order subclass, got {len(order_subclasses)}. "
+                f"ModuleImporter is creating duplicate class instances."
+            )
+        finally:
+            _cleanup(tmpdir)
+            self._cleanup_dynamic_modules(src_dir)
+            
+    def test_model_named_models_py_is_excluded_by_default(self, tmp_path):
+        """A model file named ``models.py`` should be excluded from scanning
+        by the default ``exclude_file_patterns``, avoiding the duplicate issue."""
+        src_dir = str(tmp_path / "src")
+        os.makedirs(src_dir, exist_ok=True)
+
+        _write_source_file(os.path.join(src_dir, "__init__.py"), "")
+
+        _write_source_file(
+            os.path.join(src_dir, "models.py"),
+            (
+                "from typing import Optional\n"
+                "from sqlmodel import Field\n"
+                "from py_spring_model import PySpringModel\n"
+                "\n"
+                "class ExcludedModel(PySpringModel, table=True):\n"
+                "    __tablename__ = 'excluded_test_model'\n"
+                "    id: Optional[int] = Field(default=None, primary_key=True)\n"
+                "    name: str\n"
+            ),
+        )
+
+        sys.path.insert(0, src_dir)
+        db_path = str(tmp_path / "excluded.db")
+        db_uri = f"sqlite:///{db_path}"
+        config_path, tmpdir = _create_app_fixture(db_uri, src_dir=src_dir)
+
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                _run_app(config_path)
+
+            sa_warnings = [
+                w for w in caught
+                if "will be replaced in the string-lookup table" in str(w.message)
+            ]
+            assert len(sa_warnings) == 0, (
+                f"Expected no SAWarning for models.py (excluded by default), "
+                f"but got {len(sa_warnings)}"
+            )
+        finally:
+            _cleanup(tmpdir)
+            for mod_name in list(sys.modules):
+                if mod_name in ("models",):
+                    del sys.modules[mod_name]
+            if src_dir in sys.path:
+                sys.path.remove(src_dir)

--- a/tests/test_e2e_py_spring_model_provider.py
+++ b/tests/test_e2e_py_spring_model_provider.py
@@ -7,13 +7,16 @@ Verifies the full starter lifecycle:
 
 import json
 import os
+import shutil
 import tempfile
 from typing import Optional
 
 import pytest
-from sqlmodel import Field
+from sqlmodel import Field, SQLModel
 
 from py_spring_model import CrudRepository, PySpringModel, PySpringModelProvider
+from py_spring_model.core.session_context_holder import SessionContextHolder
+from py_spring_model.repository.repository_base import RepositoryBase
 
 
 # ---------------------------------------------------------------------------
@@ -27,7 +30,17 @@ class Item(PySpringModel, table=True):
     quantity: int = 0
 
 
+class Category(PySpringModel, table=True):
+    __tablename__ = "e2e_category"
+    id: Optional[int] = Field(default=None, primary_key=True)
+    label: str
+
+
 class ItemRepository(CrudRepository[int, Item]):
+    ...
+
+
+class CategoryRepository(CrudRepository[int, Category]):
     ...
 
 
@@ -35,13 +48,12 @@ class ItemRepository(CrudRepository[int, Item]):
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _create_app_fixture(db_uri: str):
+def _create_app_fixture(db_uri: str, create_all_tables: bool = True):
     """Create a temporary directory with config files for PySpringApplication."""
     tmpdir = tempfile.mkdtemp()
     src_dir = os.path.join(tmpdir, "src")
     os.makedirs(src_dir, exist_ok=True)
 
-    # Write a minimal placeholder so the scanner doesn't complain
     with open(os.path.join(src_dir, "__init__.py"), "w") as f:
         f.write("")
 
@@ -56,7 +68,7 @@ def _create_app_fixture(db_uri: str):
     app_properties = {
         "py_spring_model": {
             "sqlalchemy_database_uri": db_uri,
-            "create_all_tables": True,
+            "create_all_tables": create_all_tables,
         }
     }
 
@@ -67,7 +79,7 @@ def _create_app_fixture(db_uri: str):
     with open(app_config["properties_file_path"], "w") as f:
         json.dump(app_properties, f)
 
-    return config_path
+    return config_path, tmpdir
 
 
 def _run_app(config_path: str):
@@ -82,24 +94,43 @@ def _run_app(config_path: str):
     return app
 
 
+def _cleanup(tmpdir: str):
+    """Reset all global state that PySpringModelProvider sets."""
+    SessionContextHolder.clear_session()
+
+    # Close RepositoryBase connection before resetting
+    if RepositoryBase.connection is not None:
+        try:
+            RepositoryBase.connection.close()
+        except Exception:
+            pass
+    RepositoryBase.engine = None
+    RepositoryBase.connection = None
+
+    PySpringModel._engine = None
+    PySpringModel._metadata = None
+    PySpringModel._connection = None
+    PySpringModel._models = None
+
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 # ---------------------------------------------------------------------------
 # SQLite E2E tests
 # ---------------------------------------------------------------------------
 
+@pytest.mark.e2e
 class TestPySpringModelProviderSQLite:
-    """E2E tests using SQLite in-memory database."""
+    """E2E tests using SQLite file database."""
 
     @pytest.fixture(autouse=True)
     def setup(self, tmp_path):
         self.db_path = str(tmp_path / "test.db")
         self.db_uri = f"sqlite:///{self.db_path}"
-        self.config_path = _create_app_fixture(self.db_uri)
+        self.config_path, self.tmpdir = _create_app_fixture(self.db_uri)
         self.app = _run_app(self.config_path)
         yield
-        # cleanup: reset global state
-        PySpringModel._engine = None
-        PySpringModel._metadata = None
-        PySpringModel._connection = None
+        _cleanup(self.tmpdir)
 
     def test_on_configure_registers_entities(self):
         """Starter's on_configure should have registered component, properties, and controller classes."""
@@ -174,9 +205,192 @@ class TestPySpringModelProviderSQLite:
 
 
 # ---------------------------------------------------------------------------
+# SQLite edge-case tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+class TestPySpringModelProviderEdgeCases:
+    """Edge-case tests using SQLite."""
+
+    def test_create_all_tables_false_skips_table_creation(self, tmp_path):
+        """When create_all_tables=False, tables should NOT be created."""
+        db_path = str(tmp_path / "no_tables.db")
+        db_uri = f"sqlite:///{db_path}"
+        config_path, tmpdir = _create_app_fixture(db_uri, create_all_tables=False)
+        try:
+            app = _run_app(config_path)
+            starter = app.starters[0]
+
+            from sqlalchemy import inspect as sa_inspect
+            inspector = sa_inspect(starter.sql_engine)
+            table_names = inspector.get_table_names()
+            assert "e2e_item" not in table_names
+            assert "e2e_category" not in table_names
+
+            # Engine should still be initialized
+            assert starter.sql_engine is not None
+        finally:
+            _cleanup(tmpdir)
+
+    def test_multiple_models_all_tables_created(self, tmp_path):
+        """Multiple PySpringModel subclasses should all have their tables created."""
+        db_path = str(tmp_path / "multi.db")
+        db_uri = f"sqlite:///{db_path}"
+        config_path, tmpdir = _create_app_fixture(db_uri)
+        try:
+            app = _run_app(config_path)
+            starter = app.starters[0]
+
+            from sqlalchemy import inspect as sa_inspect
+            inspector = sa_inspect(starter.sql_engine)
+            table_names = inspector.get_table_names()
+            assert "e2e_item" in table_names
+            assert "e2e_category" in table_names
+        finally:
+            _cleanup(tmpdir)
+
+    def test_multiple_models_crud_across_repositories(self, tmp_path):
+        """CRUD should work across multiple model types in the same app context."""
+        db_path = str(tmp_path / "multi_crud.db")
+        db_uri = f"sqlite:///{db_path}"
+        config_path, tmpdir = _create_app_fixture(db_uri)
+        try:
+            _run_app(config_path)
+
+            item_repo = ItemRepository()
+            cat_repo = CategoryRepository()
+
+            item_repo.save(Item(name="Bolt", quantity=100))
+            cat_repo.save(Category(label="Hardware"))
+
+            items = item_repo.find_all()
+            categories = cat_repo.find_all()
+
+            assert len(items) == 1
+            assert items[0].name == "Bolt"
+            assert len(categories) == 1
+            assert categories[0].label == "Hardware"
+        finally:
+            _cleanup(tmpdir)
+
+    def test_upsert_operations(self, tmp_path):
+        """Upsert should insert when missing and update when present."""
+        db_path = str(tmp_path / "upsert.db")
+        db_uri = f"sqlite:///{db_path}"
+        config_path, tmpdir = _create_app_fixture(db_uri)
+        try:
+            _run_app(config_path)
+            repo = ItemRepository()
+
+            # Insert via upsert (new entity)
+            item = Item(name="Screw", quantity=50)
+            repo.upsert(item, {"name": "Screw"})
+            found = repo.find_all()
+            assert len(found) == 1
+            assert found[0].name == "Screw"
+            assert found[0].quantity == 50
+
+            # Update via upsert (fetch existing, modify, then upsert)
+            existing = repo.find_by_id(found[0].id)
+            assert existing is not None
+            existing.quantity = 200
+            repo.upsert(existing, {"id": existing.id})
+            updated = repo.find_all()
+            assert len(updated) == 1
+            assert updated[0].quantity == 200
+        finally:
+            _cleanup(tmpdir)
+
+    def test_delete_all_operations(self, tmp_path):
+        """delete_all and delete_all_by_ids should work through the framework lifecycle."""
+        db_path = str(tmp_path / "delete_all.db")
+        db_uri = f"sqlite:///{db_path}"
+        config_path, tmpdir = _create_app_fixture(db_uri)
+        try:
+            _run_app(config_path)
+            repo = ItemRepository()
+
+            repo.save(Item(name="A", quantity=1))
+            repo.save(Item(name="B", quantity=2))
+            repo.save(Item(name="C", quantity=3))
+            assert len(repo.find_all()) == 3
+
+            # delete_all_by_ids
+            repo.delete_all_by_ids([1, 2])
+            remaining = repo.find_all()
+            assert len(remaining) == 1
+            assert remaining[0].name == "C"
+
+            # delete_all
+            repo.delete_all(remaining)
+            assert len(repo.find_all()) == 0
+        finally:
+            _cleanup(tmpdir)
+
+    def test_save_all_bulk_insert(self, tmp_path):
+        """save_all should bulk-insert multiple entities in one call."""
+        db_path = str(tmp_path / "save_all.db")
+        db_uri = f"sqlite:///{db_path}"
+        config_path, tmpdir = _create_app_fixture(db_uri)
+        try:
+            _run_app(config_path)
+            repo = ItemRepository()
+
+            items = [
+                Item(name="X", quantity=10),
+                Item(name="Y", quantity=20),
+                Item(name="Z", quantity=30),
+            ]
+            repo.save_all(items)
+
+            found = repo.find_all()
+            assert len(found) == 3
+            names = {i.name for i in found}
+            assert names == {"X", "Y", "Z"}
+        finally:
+            _cleanup(tmpdir)
+
+    def test_missing_properties_raises_error(self, tmp_path):
+        """When py_spring_model properties key is missing, the app should fail at startup."""
+        from py_spring_core import PySpringApplication
+
+        tmpdir = str(tmp_path / "bad_props")
+        os.makedirs(tmpdir, exist_ok=True)
+        src_dir = os.path.join(tmpdir, "src")
+        os.makedirs(src_dir, exist_ok=True)
+        with open(os.path.join(src_dir, "__init__.py"), "w") as f:
+            f.write("")
+
+        app_config = {
+            "app_src_target_dir": src_dir,
+            "server_config": {"host": "0.0.0.0", "port": 8080, "enabled": False},
+            "properties_file_path": os.path.join(tmpdir, "application-properties.json"),
+            "loguru_config": {"log_file_path": "", "log_level": "DEBUG"},
+            "shutdown_config": {"timeout_seconds": 5.0, "enabled": False},
+        }
+
+        # Empty properties — no py_spring_model key
+        config_path = os.path.join(tmpdir, "app-config.json")
+        with open(config_path, "w") as f:
+            json.dump(app_config, f)
+        with open(app_config["properties_file_path"], "w") as f:
+            json.dump({}, f)
+
+        with pytest.raises(TypeError, match="py_spring_model is not found"):
+            app = PySpringApplication(
+                config_path,
+                starters=[PySpringModelProvider()],
+            )
+            app.run()
+
+        _cleanup(tmpdir)
+
+
+# ---------------------------------------------------------------------------
 # PostgreSQL E2E tests (testcontainers)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.e2e
 class TestPySpringModelProviderPostgres:
     """E2E tests using PostgreSQL via testcontainers."""
 
@@ -187,12 +401,10 @@ class TestPySpringModelProviderPostgres:
         self.pg = PostgresContainer("postgres:16-alpine")
         self.pg.start()
         db_uri = self.pg.get_connection_url()
-        self.config_path = _create_app_fixture(db_uri)
+        self.config_path, self.tmpdir = _create_app_fixture(db_uri)
         self.app = _run_app(self.config_path)
         yield
-        PySpringModel._engine = None
-        PySpringModel._metadata = None
-        PySpringModel._connection = None
+        _cleanup(self.tmpdir)
         self.pg.stop()
 
     def test_on_initialized_creates_engine_postgres(self):
@@ -209,6 +421,7 @@ class TestPySpringModelProviderPostgres:
         inspector = sa_inspect(starter.sql_engine)
         table_names = inspector.get_table_names()
         assert "e2e_item" in table_names
+        assert "e2e_category" in table_names
 
     def test_crud_operations_postgres(self):
         """Full CRUD cycle against PostgreSQL."""
@@ -251,3 +464,32 @@ class TestPySpringModelProviderPostgres:
         """The framework should have set app_context on the starter."""
         starter = self.app.starters[0]
         assert starter.app_context is not None
+
+    def test_upsert_postgres(self):
+        """Upsert should work against PostgreSQL."""
+        repo = ItemRepository()
+
+        # Insert via upsert
+        repo.upsert(Item(name="PGItem", quantity=7), {"name": "PGItem"})
+        found = repo.find_all()
+        assert len(found) == 1
+        assert found[0].quantity == 7
+
+        # Update via upsert (fetch existing, modify, then upsert)
+        existing = repo.find_by_id(found[0].id)
+        assert existing is not None
+        existing.quantity = 99
+        repo.upsert(existing, {"id": existing.id})
+        updated = repo.find_all()
+        assert len(updated) == 1
+        assert updated[0].quantity == 99
+
+    def test_save_all_postgres(self):
+        """save_all bulk insert against PostgreSQL."""
+        repo = ItemRepository()
+        repo.save_all([
+            Item(name="P1", quantity=1),
+            Item(name="P2", quantity=2),
+        ])
+        found = repo.find_all()
+        assert len(found) == 2

--- a/tests/test_e2e_py_spring_model_provider.py
+++ b/tests/test_e2e_py_spring_model_provider.py
@@ -1,0 +1,253 @@
+"""
+E2E tests for PySpringModelProvider lifecycle with SQLite and PostgreSQL backends.
+
+Verifies the full starter lifecycle:
+  on_configure -> IoC container build -> on_initialized -> table creation -> CRUD
+"""
+
+import json
+import os
+import tempfile
+from typing import Optional
+
+import pytest
+from sqlmodel import Field
+
+from py_spring_model import CrudRepository, PySpringModel, PySpringModelProvider
+
+
+# ---------------------------------------------------------------------------
+# Test models & repositories
+# ---------------------------------------------------------------------------
+
+class Item(PySpringModel, table=True):
+    __tablename__ = "e2e_item"
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    quantity: int = 0
+
+
+class ItemRepository(CrudRepository[int, Item]):
+    ...
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_app_fixture(db_uri: str):
+    """Create a temporary directory with config files for PySpringApplication."""
+    tmpdir = tempfile.mkdtemp()
+    src_dir = os.path.join(tmpdir, "src")
+    os.makedirs(src_dir, exist_ok=True)
+
+    # Write a minimal placeholder so the scanner doesn't complain
+    with open(os.path.join(src_dir, "__init__.py"), "w") as f:
+        f.write("")
+
+    app_config = {
+        "app_src_target_dir": src_dir,
+        "server_config": {"host": "0.0.0.0", "port": 8080, "enabled": False},
+        "properties_file_path": os.path.join(tmpdir, "application-properties.json"),
+        "loguru_config": {"log_file_path": "", "log_level": "DEBUG"},
+        "shutdown_config": {"timeout_seconds": 5.0, "enabled": False},
+    }
+
+    app_properties = {
+        "py_spring_model": {
+            "sqlalchemy_database_uri": db_uri,
+            "create_all_tables": True,
+        }
+    }
+
+    config_path = os.path.join(tmpdir, "app-config.json")
+    with open(config_path, "w") as f:
+        json.dump(app_config, f)
+
+    with open(app_config["properties_file_path"], "w") as f:
+        json.dump(app_properties, f)
+
+    return config_path
+
+
+def _run_app(config_path: str):
+    """Run the PySpring application with PySpringModelProvider."""
+    from py_spring_core import PySpringApplication
+
+    app = PySpringApplication(
+        config_path,
+        starters=[PySpringModelProvider()],
+    )
+    app.run()
+    return app
+
+
+# ---------------------------------------------------------------------------
+# SQLite E2E tests
+# ---------------------------------------------------------------------------
+
+class TestPySpringModelProviderSQLite:
+    """E2E tests using SQLite in-memory database."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        self.db_path = str(tmp_path / "test.db")
+        self.db_uri = f"sqlite:///{self.db_path}"
+        self.config_path = _create_app_fixture(self.db_uri)
+        self.app = _run_app(self.config_path)
+        yield
+        # cleanup: reset global state
+        PySpringModel._engine = None
+        PySpringModel._metadata = None
+        PySpringModel._connection = None
+
+    def test_on_configure_registers_entities(self):
+        """Starter's on_configure should have registered component, properties, and controller classes."""
+        starter = self.app.starters[0]
+        assert isinstance(starter, PySpringModelProvider)
+
+        from py_spring_model.core.commons import PySpringModelProperties
+        from py_spring_model.py_spring_model_rest import PySpringModelRestService
+        from py_spring_model.py_spring_model_rest.controller.session_controller import SessionController
+
+        assert PySpringModelProperties in starter.properties_classes
+        assert PySpringModelRestService in starter.component_classes
+        assert SessionController in starter.rest_controller_classes
+
+    def test_on_initialized_creates_engine(self):
+        """After on_initialized, the starter should have a live SQLAlchemy engine."""
+        starter = self.app.starters[0]
+        assert hasattr(starter, "sql_engine")
+        assert starter.sql_engine is not None
+        assert str(starter.sql_engine.url).startswith("sqlite")
+
+    def test_tables_created(self):
+        """on_initialized with create_all_tables=True should create the e2e_item table."""
+        from sqlalchemy import inspect as sa_inspect
+
+        starter = self.app.starters[0]
+        inspector = sa_inspect(starter.sql_engine)
+        table_names = inspector.get_table_names()
+        assert "e2e_item" in table_names
+
+    def test_crud_operations(self):
+        """Full CRUD cycle through the framework-initialized repository."""
+        repo = ItemRepository()
+
+        # Create
+        item = Item(name="Widget", quantity=10)
+        repo.save(item)
+        assert item.id is not None
+
+        # Read
+        found = repo.find_by_id(item.id)
+        assert found is not None
+        assert found.name == "Widget"
+        assert found.quantity == 10
+
+        # Update
+        found.quantity = 20
+        repo.save(found)
+        updated = repo.find_by_id(item.id)
+        assert updated is not None
+        assert updated.quantity == 20
+
+        # Delete
+        assert repo.delete_by_id(item.id)
+        assert repo.find_by_id(item.id) is None
+
+    def test_find_all(self):
+        """Bulk insert and find_all should work through the framework lifecycle."""
+        repo = ItemRepository()
+        repo.save(Item(name="A", quantity=1))
+        repo.save(Item(name="B", quantity=2))
+
+        items = repo.find_all()
+        assert len(items) == 2
+        names = {i.name for i in items}
+        assert names == {"A", "B"}
+
+    def test_app_context_set_on_starter(self):
+        """The framework should have set app_context on the starter."""
+        starter = self.app.starters[0]
+        assert starter.app_context is not None
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL E2E tests (testcontainers)
+# ---------------------------------------------------------------------------
+
+class TestPySpringModelProviderPostgres:
+    """E2E tests using PostgreSQL via testcontainers."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        from testcontainers.postgres import PostgresContainer
+
+        self.pg = PostgresContainer("postgres:16-alpine")
+        self.pg.start()
+        db_uri = self.pg.get_connection_url()
+        self.config_path = _create_app_fixture(db_uri)
+        self.app = _run_app(self.config_path)
+        yield
+        PySpringModel._engine = None
+        PySpringModel._metadata = None
+        PySpringModel._connection = None
+        self.pg.stop()
+
+    def test_on_initialized_creates_engine_postgres(self):
+        """After on_initialized, engine URL should point to PostgreSQL."""
+        starter = self.app.starters[0]
+        assert hasattr(starter, "sql_engine")
+        assert "postgresql" in str(starter.sql_engine.url)
+
+    def test_tables_created_postgres(self):
+        """Tables should be created in PostgreSQL."""
+        from sqlalchemy import inspect as sa_inspect
+
+        starter = self.app.starters[0]
+        inspector = sa_inspect(starter.sql_engine)
+        table_names = inspector.get_table_names()
+        assert "e2e_item" in table_names
+
+    def test_crud_operations_postgres(self):
+        """Full CRUD cycle against PostgreSQL."""
+        repo = ItemRepository()
+
+        # Create
+        item = Item(name="Gadget", quantity=5)
+        repo.save(item)
+        assert item.id is not None
+
+        # Read
+        found = repo.find_by_id(item.id)
+        assert found is not None
+        assert found.name == "Gadget"
+        assert found.quantity == 5
+
+        # Update
+        found.quantity = 50
+        repo.save(found)
+        updated = repo.find_by_id(item.id)
+        assert updated is not None
+        assert updated.quantity == 50
+
+        # Delete
+        assert repo.delete_by_id(item.id)
+        assert repo.find_by_id(item.id) is None
+
+    def test_find_all_postgres(self):
+        """Bulk insert and find_all against PostgreSQL."""
+        repo = ItemRepository()
+        repo.save(Item(name="X", quantity=10))
+        repo.save(Item(name="Y", quantity=20))
+
+        items = repo.find_all()
+        assert len(items) == 2
+        names = {i.name for i in items}
+        assert names == {"X", "Y"}
+
+    def test_app_context_set_on_starter_postgres(self):
+        """The framework should have set app_context on the starter."""
+        starter = self.app.starters[0]
+        assert starter.app_context is not None


### PR DESCRIPTION
**`PySpringModelProvider` replaces `provide_py_spring_model()` factory function.**

The provider has been refactored from a multi-inheritance class (`PySpringStarter` + `Component` + `ApplicationContextRequired`) to a clean `PySpringStarter` subclass using the new lifecycle hooks.

Before:

```python
from py_spring_model import provide_py_spring_model
from py_spring_core import PySpringApplication

app = PySpringApplication(
    "./app-config.json",
    entity_providers=[provide_py_spring_model()],
)
app.run()
```

After:

```python
from py_spring_model import PySpringModelProvider
from py_spring_core import PySpringApplication

app = PySpringApplication(
    "./app-config.json",
    starters=[PySpringModelProvider()],
)
app.run()
```

**Removed exports:**

| Removed | Replacement |
|---------|-------------|
| `provide_py_spring_model()` | `PySpringModelProvider()` |
| `ApplicationContextNotSetError` | `RuntimeError` with descriptive message |

### What Changed

#### `py_spring_model_provider.py`

- `PySpringModelProvider` now extends only `PySpringStarter` (removed `Component` and `ApplicationContextRequired` mixins).
- Entity registration (`SessionController`, `PySpringModelRestService`, `PySpringModelProperties`) moved to `on_configure()`, which runs before the IoC container is built.
- Post-initialization logic (engine creation, table creation, repository query implementation) moved to `on_initialized()`, which runs after the IoC container is built and `app_context` is set.
- Replaced `assert` statements with explicit `RuntimeError` raises for `app_context` and properties null checks. Assertions are stripped under `python -O`; explicit raises are not.
- Removed `provide_py_spring_model()` factory function.
- Removed `ApplicationContextNotSetError` exception class.
- Fixed typo: "implemnted" -> "implemented".

#### `__init__.py`

- Exports `PySpringModelProvider` class directly instead of `provide_py_spring_model` function.
- Version bumped from `0.2.0` to `0.3.0`.

#### `pyproject.toml`

- Added dev dependencies: `testcontainers[postgres]>=4.0.0`, `psycopg2-binary>=2.9.0`.
- Added `[tool.pytest.ini_options]` with `e2e` marker registration.

### Lifecycle Order

The `PySpringModelProvider` now follows the standard `PySpringStarter` lifecycle:

1. `on_configure()` -- registers entities with the framework
2. IoC container build -- components, beans, and properties are instantiated
3. Dependency injection -- all dependencies are resolved
4. `set_context()` -- starter receives the `ApplicationContext`
5. `on_initialized()` -- creates engine, initializes models, creates tables

### E2E Test Coverage

Added `tests/test_e2e_py_spring_model_provider.py` with 20 tests across three test classes.

**`TestPySpringModelProviderSQLite`** (6 tests):

| Test | Verifies |
|------|----------|
| `test_on_configure_registers_entities` | `on_configure` appends Properties, Component, RestController classes |
| `test_on_initialized_creates_engine` | `on_initialized` creates a live SQLAlchemy engine |
| `test_tables_created` | Tables are created when `create_all_tables=True` |
| `test_crud_operations` | Full Create/Read/Update/Delete cycle via `CrudRepository` |
| `test_find_all` | Bulk insert + `find_all` |
| `test_app_context_set_on_starter` | Framework sets `app_context` on the starter |

**`TestPySpringModelProviderEdgeCases`** (7 tests):

| Test | Verifies |
|------|----------|
| `test_create_all_tables_false_skips_table_creation` | `create_all_tables=False` branch skips table creation |
| `test_multiple_models_all_tables_created` | Multiple `PySpringModel` subclasses all get tables |
| `test_multiple_models_crud_across_repositories` | CRUD across two different model/repo pairs |
| `test_upsert_operations` | Insert-via-upsert and update-via-upsert |
| `test_delete_all_operations` | `delete_all_by_ids` and `delete_all` batch operations |
| `test_save_all_bulk_insert` | `save_all` bulk insert |
| `test_missing_properties_raises_error` | Missing `py_spring_model` key fails at startup |

**`TestPySpringModelProviderPostgres`** (7 tests, via testcontainers):

| Test | Verifies |
|------|----------|
| `test_on_initialized_creates_engine_postgres` | Engine URL points to PostgreSQL |
| `test_tables_created_postgres` | Both model tables exist in PostgreSQL |
| `test_crud_operations_postgres` | Full CRUD cycle against PostgreSQL |
| `test_find_all_postgres` | Bulk operations against PostgreSQL |
| `test_app_context_set_on_starter_postgres` | `app_context` is set |
| `test_upsert_postgres` | Upsert insert + update against PostgreSQL |
| `test_save_all_postgres` | `save_all` bulk insert against PostgreSQL |

Run only fast (non-Docker) tests:

```bash
pytest -m "not e2e"
```

Run only e2e tests:

```bash
pytest -m e2e
```
