### PR TITLE
Make CRUD Route Registration Optional via Properties

### DIFF
--- a/py_spring_model/core/commons.py
+++ b/py_spring_model/core/commons.py
@@ -1,20 +1,4 @@
 from py_spring_core import Properties
-from pydantic import BaseModel, ConfigDict
-
-
-class ApplicationFileGroups(BaseModel):
-    """
-    A Pydantic model that defines the file groups for a PySpring application.
-
-    The `ApplicationFileGroups` model has the following attributes:
-
-    - `class_files`: A set of strings representing the class files for the application.
-    - `model_files`: A set of strings representing the model files for the application.
-    """
-
-    model_config = ConfigDict(protected_namespaces=())
-    class_files: set[str]
-    model_files: set[str]
 
 
 class PySpringModelProperties(Properties):
@@ -29,3 +13,4 @@ class PySpringModelProperties(Properties):
     __key__ = "py_spring_model"
     sqlalchemy_database_uri: str
     create_all_tables: bool = True
+    create_crud_routes: bool = False

--- a/py_spring_model/py_spring_model_rest/controller/py_spring_model_rest_controller.py
+++ b/py_spring_model/py_spring_model_rest/controller/py_spring_model_rest_controller.py
@@ -1,9 +1,11 @@
 from typing import Any, Type, Union
+from venv import logger
 
 from fastapi import Response, status
 from py_spring_core import RestController
 from pydantic import BaseModel
 
+from py_spring_model.core.commons import PySpringModelProperties
 from py_spring_model.core.model import PySpringModel
 from py_spring_model.py_spring_model_rest.service.py_spring_model_rest_service import (
     PySpringModelRestService,
@@ -16,9 +18,12 @@ class PySpringModelRestController(RestController):
     """
 
     rest_service: PySpringModelRestService
+    properties: PySpringModelProperties
 
     def post_construct(self) -> None:
-        self._register_resource_for_models()
+        if self.properties.create_crud_routes:
+            logger.info("[CRUD ROUTE REGISTRATION] Registering CRUD routes for all models.")
+            self._register_resource_for_models()
 
     def _register_resource_for_models(self) -> None:
         all_models = self.rest_service.get_all_models()
@@ -28,6 +33,8 @@ class PySpringModelRestController(RestController):
     def _register_basic_crud_routes(
         self, resource_name: str, model: Type[PySpringModel]
     ) -> None:
+        assert self.router is not None, "Router must be initialized before registering routes."
+
         @self.router.get(
             f"/{resource_name}/count",
             summary=f"Count {resource_name}",

--- a/py_spring_model/py_spring_model_rest/controller/py_spring_model_rest_controller.py
+++ b/py_spring_model/py_spring_model_rest/controller/py_spring_model_rest_controller.py
@@ -1,5 +1,5 @@
 from typing import Any, Type, Union
-from venv import logger
+from loguru import logger
 
 from fastapi import Response, status
 from py_spring_core import RestController

--- a/py_spring_model/py_spring_model_starter.py
+++ b/py_spring_model/py_spring_model_starter.py
@@ -11,6 +11,7 @@ from py_spring_model.core.model import PySpringModel
 from py_spring_model.py_spring_model_rest.controller.session_controller import SessionController
 from py_spring_model.repository.repository_base import RepositoryBase
 from py_spring_model.py_spring_model_rest import PySpringModelRestService
+from py_spring_model.py_spring_model_rest.controller.py_spring_model_rest_controller import PySpringModelRestController
 from py_spring_model.py_spring_model_rest.service.curd_repository_implementation_service.crud_repository_implementation_service import (
     CrudRepositoryImplementationService,
 )
@@ -27,6 +28,7 @@ class PySpringModelStarter(PySpringStarter):
 
     def on_configure(self) -> None:
         self.rest_controller_classes.append(SessionController)
+        self.rest_controller_classes.append(PySpringModelRestController)
         self.component_classes.append(PySpringModelRestService)
         self.properties_classes.append(PySpringModelProperties)
 

--- a/tests/test_e2e_py_spring_model_provider.py
+++ b/tests/test_e2e_py_spring_model_provider.py
@@ -146,10 +146,12 @@ class TestPySpringModelStarterSQLite:
         from py_spring_model.core.commons import PySpringModelProperties
         from py_spring_model.py_spring_model_rest import PySpringModelRestService
         from py_spring_model.py_spring_model_rest.controller.session_controller import SessionController
+        from py_spring_model.py_spring_model_rest.controller.py_spring_model_rest_controller import PySpringModelRestController
 
         assert PySpringModelProperties in starter.properties_classes
         assert PySpringModelRestService in starter.component_classes
         assert SessionController in starter.rest_controller_classes
+        assert PySpringModelRestController in starter.rest_controller_classes
 
     def test_on_initialized_creates_engine(self):
         """After on_initialized, the starter should have a live SQLAlchemy engine."""

--- a/tests/test_py_spring_model_rest_controller.py
+++ b/tests/test_py_spring_model_rest_controller.py
@@ -3,6 +3,7 @@ from sqlmodel import SQLModel, Field
 from fastapi import APIRouter
 
 from py_spring_model import PySpringModel
+from py_spring_model.core.commons import PySpringModelProperties
 from py_spring_model.core.session_context_holder import SessionContextHolder
 from py_spring_model.py_spring_model_rest.service.py_spring_model_rest_service import PySpringModelRestService
 from py_spring_model.py_spring_model_rest.controller.py_spring_model_rest_controller import PySpringModelRestController
@@ -13,6 +14,13 @@ class CtrlUser(PySpringModel, table=True):
     id: int = Field(default=None, primary_key=True)
     name: str
     email: str
+
+
+def _make_properties(create_crud_routes: bool = False) -> PySpringModelProperties:
+    return PySpringModelProperties(
+        sqlalchemy_database_uri="sqlite:///:memory:",
+        create_crud_routes=create_crud_routes,
+    )
 
 
 class TestPySpringModelRestController:
@@ -32,6 +40,7 @@ class TestPySpringModelRestController:
         controller = PySpringModelRestController.__new__(PySpringModelRestController)
         controller.rest_service = PySpringModelRestService()
         controller.router = APIRouter()
+        controller.properties = _make_properties(create_crud_routes=True)
         controller._register_basic_crud_routes("ctrl_user", CtrlUser)
         return controller
 
@@ -97,3 +106,91 @@ class TestPySpringModelRestController:
         ]
         for path, method in expected:
             assert (path, method) in all_routes, f"Missing route: {method} {path}"
+
+
+class TestPostConstructConditionalRegistration:
+    """Tests for the create_crud_routes property gating route registration."""
+
+    def setup_method(self):
+        self.engine = create_engine("sqlite:///:memory:", echo=False)
+        PySpringModel.set_engine(self.engine)
+        PySpringModel.set_metadata(SQLModel.metadata)
+        PySpringModel.set_models([CtrlUser])
+        SessionContextHolder.clear()
+        SQLModel.metadata.create_all(self.engine)
+
+    def teardown_method(self):
+        SQLModel.metadata.drop_all(self.engine)
+        SessionContextHolder.clear()
+
+    def _create_controller_with_properties(self, create_crud_routes: bool) -> PySpringModelRestController:
+        controller = PySpringModelRestController.__new__(PySpringModelRestController)
+        controller.rest_service = PySpringModelRestService()
+        controller.router = APIRouter()
+        controller.properties = _make_properties(create_crud_routes=create_crud_routes)
+        return controller
+
+    def test_post_construct_registers_routes_when_enabled(self):
+        """When create_crud_routes=True, post_construct should register CRUD routes."""
+        controller = self._create_controller_with_properties(create_crud_routes=True)
+        controller.post_construct()
+
+        routes = [
+            route for route in controller.router.routes
+            if hasattr(route, 'methods')
+        ]
+        assert len(routes) > 0
+
+    def test_post_construct_skips_routes_when_disabled(self):
+        """When create_crud_routes=False, post_construct should not register any routes."""
+        controller = self._create_controller_with_properties(create_crud_routes=False)
+        controller.post_construct()
+
+        routes = [
+            route for route in controller.router.routes
+            if hasattr(route, 'methods')
+        ]
+        assert len(routes) == 0
+
+    def test_post_construct_default_property_skips_routes(self):
+        """The default value of create_crud_routes is False, so no routes should be registered."""
+        controller = PySpringModelRestController.__new__(PySpringModelRestController)
+        controller.rest_service = PySpringModelRestService()
+        controller.router = APIRouter()
+        controller.properties = PySpringModelProperties(
+            sqlalchemy_database_uri="sqlite:///:memory:",
+        )
+        controller.post_construct()
+
+        routes = [
+            route for route in controller.router.routes
+            if hasattr(route, 'methods')
+        ]
+        assert len(routes) == 0
+
+
+class TestRegisterBasicCrudRoutesRouterAssertion:
+    """Tests for the router assertion in _register_basic_crud_routes."""
+
+    def setup_method(self):
+        self.engine = create_engine("sqlite:///:memory:", echo=False)
+        PySpringModel.set_engine(self.engine)
+        PySpringModel.set_metadata(SQLModel.metadata)
+        PySpringModel.set_models([CtrlUser])
+        SessionContextHolder.clear()
+        SQLModel.metadata.create_all(self.engine)
+
+    def teardown_method(self):
+        SQLModel.metadata.drop_all(self.engine)
+        SessionContextHolder.clear()
+
+    def test_register_routes_raises_when_router_is_none(self):
+        """_register_basic_crud_routes should raise AssertionError when router is None."""
+        controller = PySpringModelRestController.__new__(PySpringModelRestController)
+        controller.rest_service = PySpringModelRestService()
+        controller.router = None
+        controller.properties = _make_properties(create_crud_routes=True)
+
+        import pytest
+        with pytest.raises(AssertionError, match="Router must be initialized"):
+            controller._register_basic_crud_routes("ctrl_user", CtrlUser)


### PR DESCRIPTION
## Summary

- Add `create_crud_routes` property (`bool`, default `False`) to `PySpringModelProperties` to gate automatic CRUD route registration
- Register `PySpringModelRestController` in `PySpringModelStarter.on_configure` so it participates in the component lifecycle
- Remove unused `ApplicationFileGroups` model from `commons.py`

## Motivation

Previously, `PySpringModelRestController` unconditionally registered CRUD routes for all models during `post_construct`. This made it impossible to use `py_spring_model` for database access without also exposing every model as a REST resource. With this change, CRUD routes are opt-in via configuration:

```yaml
py_spring_model:
  sqlalchemy_database_uri: "sqlite:///app.db"
  create_crud_routes: true  # default: false
```

## Changes

### `py_spring_model/core/commons.py`
- Removed `ApplicationFileGroups` (unused)
- Added `create_crud_routes: bool = False` to `PySpringModelProperties`

### `py_spring_model/py_spring_model_rest/controller/py_spring_model_rest_controller.py`
- Injected `PySpringModelProperties` as a dependency
- `post_construct` now checks `self.properties.create_crud_routes` before registering routes
- Added router `assert` guard in `_register_basic_crud_routes`

### `py_spring_model/py_spring_model_starter.py`
- Added `PySpringModelRestController` to `rest_controller_classes` in `on_configure`

### Tests
- Updated existing controller tests to supply the new `properties` dependency
- Added `TestPostConstructConditionalRegistration` — verifies routes are registered only when `create_crud_routes=True` and skipped when `False` or default
- Added `TestRegisterBasicCrudRoutesRouterAssertion` — verifies `AssertionError` when router is `None`
- Updated e2e starter test to assert `PySpringModelRestController` is registered

## Test Plan

- [x] `pytest tests/test_py_spring_model_rest_controller.py` — all controller and conditional registration tests pass
- [x] `pytest tests/test_e2e_py_spring_model_provider.py` — starter registration e2e tests pass
