### PR TITLE
Typed OpenAPI Schema for CRUD Route Request Bodies

### DIFF
--- a/py_spring_model/py_spring_model_rest/controller/py_spring_model_rest_controller.py
+++ b/py_spring_model/py_spring_model_rest/controller/py_spring_model_rest_controller.py
@@ -3,7 +3,7 @@ from loguru import logger
 
 from fastapi import Response, status
 from py_spring_core import RestController
-from pydantic import BaseModel
+from pydantic import BaseModel, create_model
 
 from py_spring_model.core.commons import PySpringModelProperties
 from py_spring_model.core.model import PySpringModel
@@ -30,10 +30,18 @@ class PySpringModelRestController(RestController):
         for resource_name, model in all_models.items():
             self._register_basic_crud_routes(resource_name, model)
 
+    @staticmethod
+    def _create_request_model(model: Type[PySpringModel]) -> Type[BaseModel]:
+        fields = {}
+        for name, field_info in model.model_fields.items():
+            fields[name] = (field_info.annotation, field_info)
+        return create_model(f"{model.__name__}Input", **fields)
+
     def _register_basic_crud_routes(
         self, resource_name: str, model: Type[PySpringModel]
     ) -> None:
         assert self.router is not None, "Router must be initialized before registering routes."
+        request_model = self._create_request_model(model)
 
         @self.router.get(
             f"/{resource_name}/count",
@@ -82,10 +90,9 @@ class PySpringModelRestController(RestController):
             description=f"Create a new {resource_name} with the provided data.",
             tags=[resource_name],
         )
-        def post(model_data: dict[str, Any]):
-            model_type = self.rest_service.get_all_models()[resource_name]
+        def post(model_data: request_model):  # type: ignore[valid-type]
             try:
-                current_model = model_type.model_validate(model_data)
+                current_model = model.model_validate(model_data.model_dump(exclude_unset=True))
                 return self.rest_service.create(current_model)
             except Exception as error:
                 return Response(
@@ -98,9 +105,8 @@ class PySpringModelRestController(RestController):
             description=f"Create multiple {resource_name} at once.",
             tags=[resource_name],
         )
-        def batch_create(models: list[dict[str, Any]]):
-            model_type = self.rest_service.get_all_models()[resource_name]
-            validated = [model_type.model_validate(m) for m in models]
+        def batch_create(models: list[request_model]):  # type: ignore[valid-type]
+            validated = [model.model_validate(m.model_dump(exclude_unset=True)) for m in models]
             return self.rest_service.batch_create(validated)
 
         @self.router.put(
@@ -109,11 +115,10 @@ class PySpringModelRestController(RestController):
             description=f"Update an existing {resource_name} by its unique identifier.",
             tags=[resource_name],
         )
-        def put(id: Union[int, str], model_data: dict[str, Any]):
-            model_type = self.rest_service.get_all_models()[resource_name]
+        def put(id: Union[int, str], model_data: request_model):  # type: ignore[valid-type]
             parsed_id = self._parse_id(id, model)
             try:
-                current_model = model_type.model_validate(model_data)
+                current_model = model.model_validate(model_data.model_dump(exclude_unset=True))
                 return self.rest_service.update(parsed_id, current_model)
             except Exception as error:
                 return Response(

--- a/tests/test_rest_controller_route_handlers.py
+++ b/tests/test_rest_controller_route_handlers.py
@@ -63,6 +63,107 @@ class TestParseId:
         assert result == "abc-123"
 
 
+class TestCreateRequestModel:
+    """Tests for _create_request_model() dynamic Pydantic model generation."""
+
+    def test_request_model_has_same_fields_as_source_model(self):
+        request_model = PySpringModelRestController._create_request_model(RCHandlerUser)
+        assert set(request_model.model_fields.keys()) == set(RCHandlerUser.model_fields.keys())
+
+    def test_request_model_preserves_required_fields(self):
+        request_model = PySpringModelRestController._create_request_model(RCHandlerUser)
+        assert request_model.model_fields["name"].is_required()
+        assert request_model.model_fields["email"].is_required()
+
+    def test_request_model_preserves_optional_fields(self):
+        request_model = PySpringModelRestController._create_request_model(RCHandlerUser)
+        assert not request_model.model_fields["id"].is_required()
+
+    def test_request_model_validates_missing_required_fields(self):
+        request_model = PySpringModelRestController._create_request_model(RCHandlerUser)
+        with pytest.raises(Exception):
+            request_model.model_validate({"bad_field": 123})
+
+    def test_request_model_accepts_valid_data(self):
+        request_model = PySpringModelRestController._create_request_model(RCHandlerUser)
+        instance = request_model.model_validate({"name": "Alice", "email": "a@e.com"})
+        assert instance.name == "Alice"
+        assert instance.email == "a@e.com"
+
+    def test_request_model_name_includes_source_model_name(self):
+        request_model = PySpringModelRestController._create_request_model(RCHandlerUser)
+        assert "RCHandlerUser" in request_model.__name__
+
+
+class TestOpenAPISchemaGeneration:
+    """Tests that OpenAPI schema contains proper field definitions instead of generic additionalProperties."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        PySpringModel.set_engine(engine)
+        PySpringModel.set_metadata(SQLModel.metadata)
+        PySpringModel.set_models([RCHandlerUser])
+        RCHandlerUser.metadata.create_all(engine)
+
+        controller = PySpringModelRestController.__new__(PySpringModelRestController)
+        controller.rest_service = PySpringModelRestService()
+        controller.router = APIRouter()
+        controller.properties = PySpringModelProperties(
+            sqlalchemy_database_uri="sqlite:///:memory:",
+            create_crud_routes=True,
+        )
+        controller._register_basic_crud_routes("rc_handler_user", RCHandlerUser)
+
+        app = FastAPI()
+        app.include_router(controller.router)
+        self.client = TestClient(app)
+        self.openapi_schema = self.client.get("/openapi.json").json()
+        yield
+        RCHandlerUser.metadata.drop_all(engine)
+        PySpringModel._engine = None
+        PySpringModel._metadata = None
+
+    def _get_request_body_schema(self, path: str, method: str) -> dict:
+        ref = (
+            self.openapi_schema["paths"][path][method]["requestBody"]["content"][
+                "application/json"
+            ]["schema"]["$ref"]
+        )
+        schema_name = ref.split("/")[-1]
+        return self.openapi_schema["components"]["schemas"][schema_name]
+
+    def test_post_schema_has_model_fields(self):
+        schema = self._get_request_body_schema("/rc_handler_user", "post")
+        assert "name" in schema["properties"]
+        assert "email" in schema["properties"]
+        assert "id" in schema["properties"]
+
+    def test_post_schema_has_correct_types(self):
+        schema = self._get_request_body_schema("/rc_handler_user", "post")
+        assert schema["properties"]["name"]["type"] == "string"
+        assert schema["properties"]["email"]["type"] == "string"
+        assert schema["properties"]["id"]["type"] == "integer"
+
+    def test_post_schema_has_required_fields(self):
+        schema = self._get_request_body_schema("/rc_handler_user", "post")
+        assert "name" in schema["required"]
+        assert "email" in schema["required"]
+
+    def test_post_schema_does_not_have_additional_properties(self):
+        schema = self._get_request_body_schema("/rc_handler_user", "post")
+        assert "additionalProperties" not in schema
+
+    def test_put_schema_has_model_fields(self):
+        schema = self._get_request_body_schema("/rc_handler_user/{id}", "put")
+        assert "name" in schema["properties"]
+        assert "email" in schema["properties"]
+
+
 class TestRestControllerRouteHandlers:
     """Tests that invoke route handlers through FastAPI TestClient."""
 
@@ -110,9 +211,9 @@ class TestRestControllerRouteHandlers:
         data = response.json()
         assert data["name"] == "Alice"
 
-    def test_post_create_invalid_data_returns_400(self):
+    def test_post_create_invalid_data_returns_422(self):
         response = self.client.post("/rc_handler_user", json={"invalid_field": "value"})
-        assert response.status_code == 400
+        assert response.status_code == 422
 
     def test_get_by_id(self):
         user = self._create_user()
@@ -162,10 +263,10 @@ class TestRestControllerRouteHandlers:
         assert response.status_code == 200
         assert response.json()["name"] == "Alice Updated"
 
-    def test_put_update_invalid_data_returns_400(self):
+    def test_put_update_invalid_data_returns_422(self):
         user = self._create_user()
         response = self.client.put(f"/rc_handler_user/{user['id']}", json={"bad_field": 123})
-        assert response.status_code == 400
+        assert response.status_code == 422
 
     def test_delete_by_id(self):
         user = self._create_user()


### PR DESCRIPTION
### Problem

Auto-generated CRUD routes used `dict[str, Any]` as the request body type for POST, PUT, and batch POST endpoints. This caused Swagger UI to display a generic example:

```json
{
  "additionalProp1": {}
}
```

Users had no way to know which fields were available, their types, or which were required — without reading the source code.

### Solution

Dynamically create a plain Pydantic request model from each `PySpringModel`'s fields at route registration time via `pydantic.create_model()`. This gives FastAPI a fully typed schema to render in Swagger UI.

**Before** — `dict[str, Any]` parameter, no schema info:
```json
{ "additionalProp1": {} }
```

**After** — typed request model with field names, types, required markers, and defaults:
```json
{
  "id": 0,
  "name": "string",
  "email": "string",
  "age": 0,
  "salary": 0.0,
  "active": true
}
```

### Changes

- **`py_spring_model_rest_controller.py`**
  - Added `_create_request_model()` — builds a non-table Pydantic model from a `PySpringModel`'s fields
  - Updated `post`, `batch_create`, and `put` handlers to use the typed request model
  - Conversion back to the table model uses `model_dump(exclude_unset=True)` to avoid `id=None` validation issues

- **`test_rest_controller_route_handlers.py`**
  - Added `TestCreateRequestModel` (6 tests) — validates field preservation, required/optional handling, and validation behavior
  - Added `TestOpenAPISchemaGeneration` (5 tests) — verifies the OpenAPI schema contains proper field names, types, and required markers
  - Updated 2 existing tests: invalid data now returns 422 (FastAPI validation) instead of 400

### Breaking Change

Invalid request data on POST/PUT endpoints now returns **422** (FastAPI's standard `Unprocessable Entity`) with detailed per-field errors, instead of a generic **400**.
