### PR TITLE
Resolve Plural Method Name Fields to Singular Columns

### DIFF
--- a/py_spring_model/py_spring_model_rest/service/curd_repository_implementation_service/method_query_builder.py
+++ b/py_spring_model/py_spring_model_rest/service/curd_repository_implementation_service/method_query_builder.py
@@ -217,7 +217,7 @@ class _MetodQueryBuilder:
                     related_model=rel_fields[rel_name],
                 )
             else:
-                resolved_field = base_token
+                resolved_field = self._resolve_plural_field(base_token, direct_columns)
 
             # Record operation and classify the field
             if operation:
@@ -292,6 +292,23 @@ class _MetodQueryBuilder:
     def _extract_base_field(self, field: str, operation: FieldOperation) -> str:
         suffix = self._OPERATION_TO_SUFFIX[operation]
         return field[: -len(suffix)]
+
+    @staticmethod
+    def _resolve_plural_field(token: str, direct_columns: set[str]) -> str:
+        """Resolve a field token to its column name, trying singular form if plural doesn't match."""
+        if token in direct_columns or not direct_columns:
+            return token
+        if token.endswith("ies"):
+            singular = token[:-3] + "y"
+        elif token.endswith("ses"):
+            singular = token[:-2]
+        elif token.endswith("s") and len(token) > 1:
+            singular = token[:-1]
+        else:
+            return token
+        if singular in direct_columns:
+            return singular
+        return token
 
     def _validate_fields(
         self,

--- a/tests/test_method_query_builder.py
+++ b/tests/test_method_query_builder.py
@@ -575,3 +575,16 @@ class TestFieldValidation:
         builder = _MetodQueryBuilder("find_all_by_children_nonexistent_gt")
         with pytest.raises(ValueError, match=r"field 'nonexistent' does not exist on related model 'ChildModel'"):
             builder.parse_query(model_type=ParentModel)
+
+    def test_plural_method_name_resolves_to_singular_column(self):
+        """'find_all_by_names_in' should resolve 'names' to column 'name'."""
+        builder = _MetodQueryBuilder("find_all_by_names_in")
+        query = builder.parse_query(model_type=ParentModel)
+        assert "name" in query.required_fields
+        assert "names" not in query.required_fields
+
+    def test_plural_method_name_without_matching_singular_still_fails(self):
+        """'find_all_by_nonexistents_in' should still fail if singular also doesn't exist."""
+        builder = _MetodQueryBuilder("find_all_by_nonexistents_in")
+        with pytest.raises(ValueError, match=r"field 'nonexistents' does not exist on model 'ParentModel'"):
+            builder.parse_query(model_type=ParentModel)


### PR DESCRIPTION
## Resolve Plural Method Name Fields to Singular Columns

### Problem

When using `_in` operations, it's natural to name methods with plural fields (e.g. `find_all_by_shipping_numbers_in`). However, the field parsed from the method name (`shipping_numbers`) doesn't match the actual column (`shipping_number`), causing the new startup validation to reject it:

```
ValueError: Method 'find_all_by_shipping_numbers_in': field 'shipping_numbers' does not exist on model 'ShippingRecord'. Available columns: ['shipping_number', ...]
```

### Solution

Added `_resolve_plural_field` to the field resolution step in `parse_query`. When a token doesn't match a direct column, it tries the singular form:

- `shipping_numbers` → `shipping_number`
- `categories` → `category` (ies → y)
- `addresses` → `addresse` → falls back to original if singular also doesn't match

This resolves at parse time, so both validation AND runtime query execution use the correct column name.

### Changes

- **Added `_resolve_plural_field`** static method to `_MetodQueryBuilder`
- **Integrated** into the field resolution loop (replaces direct `base_token` assignment)
- **2 new tests**: plural resolution success + plural with no matching singular still fails validation

### Test Plan

- [x] `find_all_by_names_in` resolves to column `name`
- [x] `find_all_by_nonexistents_in` still raises ValueError
- [x] Full suite: 504 passed, 0 failures
