### PR TITLE
Fail-Fast Null Validation & Empty Collection Query Fixes

### DIFF
--- a/py_spring_model/py_spring_model_rest/service/curd_repository_implementation_service/crud_repository_implementation_service.py
+++ b/py_spring_model/py_spring_model_rest/service/curd_repository_implementation_service/crud_repository_implementation_service.py
@@ -6,14 +6,15 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    ParamSpec
+    ParamSpec,
+    get_origin,
 )
 
 from loguru import logger
 from py_spring_core import Component
 from pydantic import BaseModel
 from sqlalchemy import ColumnElement, delete, func, inspect as sa_inspect
-from sqlalchemy.sql import and_, or_
+from sqlalchemy.sql import and_, or_, false as sa_false, true as sa_true
 from sqlmodel import select
 from sqlmodel.sql.expression import SelectOfScalar
 
@@ -148,6 +149,16 @@ class CrudRepositoryImplementationService:
 
         return mapping
 
+    @staticmethod
+    def _validate_collection_not_none(param_name: str, value: Any, annotation: Any) -> None:
+        if value is not None:
+            return
+        origin = get_origin(annotation)
+        if origin in (list, set) or annotation in (list, set):
+            raise TypeError(
+                f"Parameter '{param_name}' expects {annotation}, got None"
+            )
+
     def _cast_plural_to_singular(self, word: str) -> str:
         if word.endswith('ies'):
             return word[:-3] + 'y'
@@ -162,6 +173,8 @@ class CrudRepositoryImplementationService:
             for param_name, value in kwargs.items():
                 if param_name in param_to_field_mapping:
                     field_name = param_to_field_mapping[param_name]
+                    if param_name in original_func_annotations:
+                        self._validate_collection_not_none(param_name, value, original_func_annotations[param_name])
                     field_kwargs[field_name] = value
                 else:
                     raise ValueError(f"Unknown parameter '{param_name}'. Expected parameters: {list(param_to_field_mapping.keys())}")
@@ -329,7 +342,7 @@ class CrudRepositoryImplementationService:
             )
 
         if len(param_value) == 0:
-            return column == None
+            return sa_false()
 
         return column.in_(param_value)
 
@@ -341,7 +354,7 @@ class CrudRepositoryImplementationService:
             )
 
         if len(param_value) == 0:
-            return column != None
+            return sa_true()
 
         return ~column.in_(param_value)
 

--- a/tests/test_crud_repository_implementation_service.py
+++ b/tests/test_crud_repository_implementation_service.py
@@ -131,8 +131,8 @@ class TestQuery:
     def test_in_operator_empty_list(self, implementation_service: CrudRepositoryImplementationService):
         parsed_query = _MetodQueryBuilder("find_by_status_in").parse_query()
         statement = implementation_service._get_sql_statement(User, parsed_query, {"status": []})
-        # Empty list should result in a condition that's always false
-        assert "IS NULL" in str(statement) or "= NULL" in str(statement)
+        sql = str(statement).lower()
+        assert "false" in sql or "1 != 1" in sql or "0 = 1" in sql
 
     def test_in_operator_invalid_type(self, implementation_service: CrudRepositoryImplementationService):
         parsed_query = _MetodQueryBuilder("find_by_status_in").parse_query()
@@ -175,6 +175,21 @@ class TestQuery:
         # Empty list should return no results
         results = user_repository.find_all_by_status_in(status=[])
         assert len(results) == 0
+
+    def test_null_list_param_raises_type_error(self, user_repository: UserRepository, implementation_service: CrudRepositoryImplementationService):
+        implementation_service._implemenmt_query(user_repository.__class__)
+        with pytest.raises(TypeError, match="Parameter 'status' expects .*, got None"):
+            user_repository.find_all_by_status_in(status=None)
+
+    def test_null_set_param_raises_type_error(self, implementation_service: CrudRepositoryImplementationService):
+        with pytest.raises(TypeError, match="Parameter 'ids' expects .*, got None"):
+            CrudRepositoryImplementationService._validate_collection_not_none("ids", None, set[int])
+
+    def test_null_scalar_param_passes_validation(self, implementation_service: CrudRepositoryImplementationService):
+        CrudRepositoryImplementationService._validate_collection_not_none("name", None, str)
+
+    def test_non_null_collection_passes_validation(self, implementation_service: CrudRepositoryImplementationService):
+        CrudRepositoryImplementationService._validate_collection_not_none("status", ["active"], list[str])
 
     def test_parameter_field_mapping_simple(self, implementation_service: CrudRepositoryImplementationService):
         """Test that parameter field mapping works with exact name matching and plural support"""


### PR DESCRIPTION
### Problem

Two issues with collection-typed query method parameters:

1. **`None` passed to `list`/`set` parameters silently propagated**, causing downstream `NoneType is not iterable` errors deep in query execution — hard to debug and easy to miss.

2. **Empty list edge cases produced wrong SQL:**
   - `IN ([])` generated `column IS NULL` instead of an always-false condition — returned rows where the column was NULL rather than returning no results.
   - `NOT IN ([])` generated `column IS NOT NULL` instead of an always-true condition — excluded NULL rows rather than returning all results.

### Solution

Aligned with Spring Data JPA's proven conventions:

| Scenario | Spring Data JPA | Before (broken) | After |
|---|---|---|---|
| `null` param for `List`/`Set` | `IllegalArgumentException` | Silent `None` propagation | `TypeError` at method entry |
| `IN ([])` | `WHERE 1=0` (empty result) | `WHERE col IS NULL` | `WHERE false` |
| `NOT IN ([])` | `WHERE true` (all results) | `WHERE col IS NOT NULL` | `WHERE true` |

### Changes

**`crud_repository_implementation_service.py`**
- Added `_validate_collection_not_none()` — rejects `None` for parameters annotated as `list` or `set` with a clear `TypeError`
- Wired validation into `create_implementation_wrapper` before field mapping
- Fixed `_create_in_condition`: empty list now returns `sa_false()` instead of `column == None`
- Fixed `_create_not_in_condition`: empty list now returns `sa_true()` instead of `column != None`

**`tests/test_crud_repository_implementation_service.py`**
- `test_null_list_param_raises_type_error` — end-to-end: `None` to `find_all_by_status_in` raises `TypeError`
- `test_null_set_param_raises_type_error` — unit: `set[int]` annotation with `None` raises
- `test_null_scalar_param_passes_validation` — unit: `str` annotation with `None` passes through (no false positive)
- `test_non_null_collection_passes_validation` — unit: valid list value passes through
- Fixed `test_in_operator_empty_list` assertion to check for `false` instead of `IS NULL`

### Test Plan

- [x] `None` to `list`-typed param raises `TypeError` with clear message
- [x] `None` to `set`-typed param raises `TypeError`
- [x] `None` to scalar param (`str`) passes through — no false positives
- [x] Valid collection values pass through unchanged
- [x] `IN ([])` returns empty results (58 unit tests pass)
- [x] `NOT IN ([])` returns all results (18 field operation tests pass)
- [x] Full suite: all tests green
