### PR TITLE
Fix: Delete Methods Use Primary Key Lookup & Return Void per Spring Conventions

### DIFF
--- a/py_spring_model/repository/crud_repository.py
+++ b/py_spring_model/repository/crud_repository.py
@@ -144,49 +144,31 @@ class CrudRepository(RepositoryBase, Generic[ID, T]):
         return entity_list
 
     @Transactional
-    def delete(self, entity: T) -> bool:
+    def delete(self, entity: T) -> None:
         session = SessionContextHolder.get_or_create_session()
-        optional_instance = self._find_by_query(entity.model_dump())
-        if optional_instance is None:
-            return False
-        session.delete(optional_instance)
-        return True
-
-    @Transactional
-    def delete_all(self, entities: Iterable[T]) -> bool:
-        session = SessionContextHolder.get_or_create_session()
-        ids = [entity.id for entity in entities] # type: ignore
-        
-        statement = select(self.model_class).where(self.model_class.id.in_(ids))  # type: ignore
-        deleted_entities = self._find_all_by_statement(statement)
-        if deleted_entities is None:
-            return False
-        
-        for entity in deleted_entities:
+        if self.exists_by_id(entity.id):  # type: ignore
             session.delete(entity)
 
-        return True
-
+    @Transactional
+    def delete_all(self, entities: Iterable[T]) -> None:
+        session = SessionContextHolder.get_or_create_session()
+        for entity in entities:
+            if self.exists_by_id(entity.id):  # type: ignore
+                session.delete(entity)
 
     @Transactional
-    def delete_by_id(self, _id: ID) -> bool:
+    def delete_by_id(self, _id: ID) -> None:
         session = SessionContextHolder.get_or_create_session()
         entity = self._find_by_query({"id": _id})
-        if entity is None:
-            return False
-        session.delete(entity)
-        return True
+        if entity is not None:
+            session.delete(entity)
 
     @Transactional
-    def delete_all_by_ids(self, ids: list[ID]) -> bool:
+    def delete_all_by_ids(self, ids: list[ID]) -> None:
         session = SessionContextHolder.get_or_create_session()
         statement = select(self.model_class).where(self.model_class.id.in_(ids))  # type: ignore
-        deleted_entities = self._find_all_by_statement(statement)
-        if deleted_entities is None:
-            return False
-        for entity in deleted_entities:
+        for entity in self._find_all_by_statement(statement):
             session.delete(entity)
-        return True
 
     @Transactional
     def count(self) -> int:

--- a/tests/test_crud_repository.py
+++ b/tests/test_crud_repository.py
@@ -94,26 +94,26 @@ class TestCrudRepository:
         self.create_test_user(user_repository)
         user = user_repository.find_by_id(1)
         assert user is not None
-        assert user_repository.delete(user)
+        user_repository.delete(user)
         assert user_repository.find_by_id(1) is None
 
     def test_delete_by_id(self, user_repository: UserRepository):
         self.create_test_user(user_repository)
         user = user_repository.find_by_id(1)
         assert user is not None
-        assert user_repository.delete_by_id(1)
+        user_repository.delete_by_id(1)
         assert user_repository.find_by_id(1) is None
 
     def test_delete_all(self, user_repository: UserRepository):
         self.create_test_user(user_repository)
         users = user_repository.find_all()
         assert len(users) == 1
-        assert user_repository.delete_all(users)
+        user_repository.delete_all(users)
         assert len(user_repository.find_all()) == 0
 
     def test_delete_all_by_ids(self, user_repository: UserRepository):
         self.create_test_user(user_repository)
-        assert user_repository.delete_all_by_ids([1])
+        user_repository.delete_all_by_ids([1])
         assert user_repository.find_by_id(1) is None
     
     def test_upsert_for_existing_user(self, user_repository: UserRepository):
@@ -153,11 +153,12 @@ class TestCrudRepository:
         self.create_test_user(user_repository)
         user = user_repository.find_by_id(1)
         assert user is not None
-        assert user_repository.delete(user)
+        user_repository.delete(user)
         assert user_repository.find_by_id(1) is None
 
     def test_delete_user_with_user_not_found(self, user_repository: UserRepository):
-        assert user_repository.delete(User(id=1, name="John Doe", email="john@example.com")) is False
+        user_repository.delete(User(id=1, name="John Doe", email="john@example.com"))
+        assert user_repository.find_by_id(1) is None
 
     def test_count_empty(self, user_repository: UserRepository):
         assert user_repository.count() == 0
@@ -219,6 +220,28 @@ class TestCrudRepository:
         self.create_test_user(user_repository)
         result = user_repository.find_all()
         assert len(result) == 1
+
+    def test_delete_with_modified_entity_field(self, user_repository: UserRepository):
+        self.create_test_user(user_repository)
+        user = user_repository.find_by_id(1)
+        assert user is not None
+
+        user.name = "Modified Name"
+
+        user_repository.delete(user)
+        assert user_repository.find_by_id(1) is None
+
+    def test_delete_all_with_modified_entity_fields(self, user_repository: UserRepository):
+        user_repository.save(User(name="Alice", email="alice@example.com"))
+        user_repository.save(User(name="Bob", email="bob@example.com"))
+
+        users = user_repository.find_all()
+        assert len(users) == 2
+
+        users[0].name = "Modified"
+
+        user_repository.delete_all(users)
+        assert len(user_repository.find_all()) == 0
 
     def test_save_all_returns_list(self, user_repository: UserRepository):
         users = [

--- a/tests/test_e2e_py_spring_model_provider.py
+++ b/tests/test_e2e_py_spring_model_provider.py
@@ -192,7 +192,7 @@ class TestPySpringModelStarterSQLite:
         assert updated.quantity == 20
 
         # Delete
-        assert repo.delete_by_id(item.id)
+        repo.delete_by_id(item.id)
         assert repo.find_by_id(item.id) is None
 
     def test_find_all(self):
@@ -454,7 +454,7 @@ class TestPySpringModelStarterPostgres:
         assert updated.quantity == 50
 
         # Delete
-        assert repo.delete_by_id(item.id)
+        repo.delete_by_id(item.id)
         assert repo.find_by_id(item.id) is None
 
     def test_find_all_postgres(self):


### PR DESCRIPTION
### Problem

`CrudRepository.delete(entity)` used `entity.model_dump()` to query by **all fields**, causing silent failures when any field was modified in memory before deletion:

```python
user = repo.find_by_id(1)       # name="John"
user.name = "Jane"               # modify in memory
repo.delete(user)                # silently returns False — no deletion!
```

The generated SQL queried every column:
```sql
SELECT ... FROM user WHERE name = 'Jane' AND email = 'john@example.com' AND id = 1
-- No match because DB still has name='John'
```

Additionally, all delete methods returned `bool`, diverging from Spring Data's `CrudRepository` which returns `void`.

### Solution

Aligned with [Spring Data CrudRepository](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/CrudRepository.html) conventions:

| Method | Before | After |
|---|---|---|
| `delete(entity)` | `model_dump()` all-field query, returns `bool` | `exists_by_id` check, returns `None` |
| `delete_all(entities)` | Re-query by IDs, returns `bool` | Direct delete with existence check, returns `None` |
| `delete_by_id(id)` | Returns `bool` | Returns `None` |
| `delete_all_by_ids(ids)` | Returns `bool` | Returns `None` |

### Changes

**`py_spring_model/repository/crud_repository.py`**
- `delete()` — replaced `_find_by_query(entity.model_dump())` with `exists_by_id(entity.id)` check
- `delete_all()` — replaced bulk ID re-query with per-entity `exists_by_id` guard
- `delete_by_id()` / `delete_all_by_ids()` — simplified control flow
- All four methods now return `None` instead of `bool`

**`tests/test_crud_repository.py`**
- Updated all delete test assertions to not check return values
- Added `test_delete_with_modified_entity_field` — reproduces the original bug
- Added `test_delete_all_with_modified_entity_fields` — verifies bulk delete with modified entities

**`tests/test_e2e_py_spring_model_provider.py`**
- Removed `assert` on `delete_by_id()` return value (2 occurrences)

### Test Plan

- [x] Modified entity still deletes correctly (`test_delete_with_modified_entity_field`)
- [x] Bulk delete with modified entities works (`test_delete_all_with_modified_entity_fields`)
- [x] Deleting non-existent entity is a silent no-op (`test_delete_user_with_user_not_found`)
- [x] All 28 crud repository tests pass
- [x] Full suite: 510 tests pass
